### PR TITLE
Fix off-by-one exponent in scientific notation (#27)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Long variable names no longer wrap onto a misaligned line; they are now
   truncated with an ellipsis (#26)
+- Off-by-one exponent in scientific notation formatting caused by
+  floating-point imprecision in `log10().floor()`, which could print e.g.
+  "10.0E5" instead of "1.0E6" (#27)
 
 ## [0.0.3]
 

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -37,7 +37,6 @@ def convert_df_scientific(df: pl.LazyFrame, varnames: Iterable[str], thr: int = 
         pl.DataFrame: new pl.DataFrame with entries converted
     """
     exprs_ex = []
-    exprs_scient = []
     name_exponents = []
     for varname in varnames:
         nan = float("nan")
@@ -51,6 +50,37 @@ def convert_df_scientific(df: pl.LazyFrame, varnames: Iterable[str], thr: int = 
             .then(var.abs().log10().floor())
             .alias(name_exponent)
         ).cast(pl.Int16)
+        exprs_ex.append(exp_ex)
+    df = df.with_columns(exprs_ex)
+
+    # log10().floor() can land one off near exact powers of ten because of
+    # floating-point error, which pushes the mantissa out of [1, 10) and
+    # prints e.g. "10.0E5" instead of "1.0E6". Nudge the exponent back in
+    # range based on the rounded mantissa it actually produces.
+    exprs_correct = []
+    for varname, name_exponent in zip(varnames, name_exponents):
+        nan = float("nan")
+        var = pl.col(varname).fill_null(nan)
+        var_exponent = pl.col(name_exponent)
+        mantissa = var.abs().truediv(pl.lit(10.0).pow(var_exponent)).round(2)
+        corrected = (
+            (
+                pl.when(mantissa.ge(10))
+                .then(var_exponent + 1)
+                .when(mantissa.lt(1) & var.ne(0))
+                .then(var_exponent - 1)
+                .otherwise(var_exponent)
+            )
+            .cast(pl.Int16)
+            .alias(name_exponent)
+        )
+        exprs_correct.append(corrected)
+    df = df.with_columns(exprs_correct)
+
+    exprs_scient = []
+    for varname, name_exponent in zip(varnames, name_exponents):
+        nan = float("nan")
+        var = pl.col(varname).fill_null(nan)
         var_exponent = pl.col(name_exponent)
         exp_scient = (
             pl.when(var.is_nan())
@@ -65,11 +95,10 @@ def convert_df_scientific(df: pl.LazyFrame, varnames: Iterable[str], thr: int = 
                 pl.format(
                     "{}E{}",
                     var.truediv(pl.lit(10.0).pow(var_exponent)).round(2),
-                    pl.col(name_exponent),
+                    var_exponent,
                 )
             )
         ).alias(varname)
-        exprs_ex.append(exp_ex)
         exprs_scient.append(exp_scient)
 
-    return df.with_columns(exprs_ex).with_columns(exprs_scient).drop(name_exponents)
+    return df.with_columns(exprs_scient).drop(name_exponents)

--- a/tests/test_scientific_conversion.py
+++ b/tests/test_scientific_conversion.py
@@ -46,3 +46,19 @@ def test_convert_df_scientific_custom_threshold():
     result = convert_df_scientific(df, ["values"], thr=3).collect()
 
     assert result["values"].to_list() == ["0.1", "10.0", "1000.0", "1.0E4", "1.0E5"]
+
+
+def test_convert_df_scientific_power_of_ten_rounding():
+    # log10().floor() is imprecise near exact powers of ten (e.g. it can put
+    # 1_000_000.0 at exponent 5 instead of 6), which used to surface as a
+    # mantissa of 10 instead of 1, e.g. "10.0E5" instead of "1.0E6".
+    df = pl.DataFrame(
+        {"values": [10.0**k for k in range(-6, 13)] + [999999.999999, -999999.999999]}
+    ).lazy()
+
+    result = convert_df_scientific(df, ["values"]).collect()["values"].to_list()
+
+    for value in result:
+        if "E" in value:
+            mantissa = value.split("E")[0].lstrip("-")
+            assert 1.0 <= float(mantissa) < 10.0, f"mantissa out of range: {value}"


### PR DESCRIPTION
Closes #27. Split out of #36.

`convert_df_scientific` derives the exponent from `log10().floor()`, which is imprecise near exact powers of ten — `1_000_000.0` lands at exponent 5 rather than 6. That pushes the mantissa outside `[1, 10)` and prints `"10.0E5"` where `"1.0E6"` was meant.

Reproducing on `main`, every power of ten from `10^-10` to `10^15`:

```
k=3   -> exponent 2  (wrong)
k=6   -> exponent 5  (wrong)
k=9   -> exponent 8  (wrong)
k=12  -> exponent 11 (wrong)
k=13  -> exponent 12 (wrong)
k=15  -> exponent 14 (wrong)
```

The fix recomputes the rounded mantissa and nudges the exponent back into range when it falls outside `[1, 10)`.

## Test plan

- [x] New test asserts the mantissa stays in `[1, 10)` across `10^-6`..`10^12` plus `±999999.999999` — it fails on `main`, passes here
- [x] Existing `test_scientific_conversion.py` cases unchanged
- [x] `pytest tests/` — 31 passed, 3 skipped (the 3 pre-existing pandas skips from #33, tracked in #43)
- [x] `ruff check .` / `ruff format --check .` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_