### PR TITLE
Truncate over-long variable names and rename the first column header (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ show_stats(df)
 ```
 
     -Date and datetime columns------------------------------------------------------
-     Var. N=100      NA%  Min         Max                     Median                
+     Col (N=100)      NA%  Min         Max                     Median                
      date_col        0    1501-01-20  1996-04-09              1755-07-20 00:00:00   
      date_col_2      0    1511-12-06  1999-05-05              1776-03-03 00:00:00   
      datetime_col    0    1501-01-20  1996-04-09 06:29:29     1755-07-20 10:10:59   
@@ -19,7 +19,7 @@ show_stats(df)
      datetime_col_2  0    1511-12-06  1999-05-05 14:12:20     1776-03-03 13:25:50   
                           23:40:13                                                  
     -Numerical columns--------------------------------------------------------------
-     Var. N=100         NA%  Avg     SD     Min     Max     Median 
+     Col (N=100)         NA%  Avg     SD     Min     Max     Median 
      float_mean_2       0    2.0     0.89   -0.36   4.12    2.0    
      float_std_2        0    0.14    2.0    -5.17   4.91    0.14   
      float_min_-7       0    -4.64   0.89   -7.0    -2.51   -4.63  
@@ -32,7 +32,7 @@ show_stats(df)
      bool_col           26   0.5     0.5    false   true    0.5    
      null_col           100                                        
     -Categorical columns------------------------------------------------------------
-     Var. N=100       NA%  Uniques  Top 1       Top 2        Top 3        
+     Col (N=100)       NA%  Uniques  Top 1       Top 2        Top 3        
      str_col          48   5        foo (15%)   ABC (13%)    bar (12%)    
      categorical_col  0    2        Fara (57%)  Car (43%)                 
      enum_col         0    3        best (36%)  worst (35%)  medium (29%) 
@@ -43,7 +43,7 @@ show_stats(df, "cat")  # Other are num, time
 ```
 
     -Categorical columns------------------------------------------------------------
-     Var. N=100       NA%  Uniques  Top 1       Top 2        Top 3        
+     Col (N=100)       NA%  Uniques  Top 1       Top 2        Top 3        
      str_col          48   5        foo (15%)   ABC (13%)    bar (12%)    
      categorical_col  0    2        Fara (57%)  Car (43%)                 
      enum_col         0    3        best (36%)  worst (35%)  medium (29%) 
@@ -54,7 +54,7 @@ df.select("U", "int_col").stats.show()
 ```
 
     -Numerical columns--------------------------------------------------------------
-     Var. N=100  NA%  Avg   SD     Min   Max   Median 
+     Col (N=100)  NA%  Avg   SD     Min   Max   Median 
      U           0    0.54  0.26   0.02  0.98  0.57   
      int_col     0    49.5  29.01  0     99    49.5   
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Long variable names no longer wrap onto a misaligned line; they are now
+  truncated with an ellipsis (#26)
+
 ## [0.0.3]
 
 ### Changed

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -79,6 +79,22 @@ def _map_cols_and_funs_for_var_type(df, var_type) -> Tuple[str]:
     return cols, _map_funs_to_var_type(var_type)
 
 
+_MAX_VAR_NAME_LEN = 30
+
+
+def _truncate_long_strings(expr: pl.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> pl.Expr:
+    """Truncates strings longer than max_len, marking the cut with an ellipsis.
+
+    Long variable names otherwise wrap onto a new, misaligned line when the
+    printed table exceeds its configured width.
+    """
+    return (
+        pl.when(expr.str.len_chars().gt(max_len))
+        .then(expr.str.slice(0, max_len - 1) + "…")
+        .otherwise(expr)
+    )
+
+
 def _map_table_type_to_var_types(table_type):
     """Maps table type to var types"""
     if table_type == "all":
@@ -302,6 +318,10 @@ class _Table:
             stat_df = stat_df.with_columns(
                 pl.col(name_var).cast(pl.Enum(new_order))
             ).sort(name_var)
+
+        stat_df = stat_df.with_columns(
+            _truncate_long_strings(pl.col(name_var).cast(pl.String)).alias(name_var)
+        )
 
         self.stat_dfs[table_type] = stat_df.collect()
 

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -274,9 +274,9 @@ class _Table:
             return
 
         if self.num_rows < 100_000:
-            name_var = f"Var. N={self.num_rows}"
+            name_var = f"Col (N={self.num_rows})"
         else:
-            name_var = f"Var. N={Decimal(self.num_rows):.2E}"
+            name_var = f"Col (N={Decimal(self.num_rows):.2E})"
         subdfs = []
 
         for var_type in _map_table_type_to_var_types(table_type):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -73,7 +73,9 @@ def test_polars_vs_pandas_numeric_stats():
     assert result_polars.shape == result_pandas.shape
 
     # Variable names should be the same
-    assert result_polars["Var. N=10"].to_list() == result_pandas["Var. N=10"].to_list()
+    assert (
+        result_polars["Col (N=10)"].to_list() == result_pandas["Col (N=10)"].to_list()
+    )
 
     # NA% should be the same (both 0)
     assert result_polars["NA%"].to_list() == result_pandas["NA%"].to_list()
@@ -100,7 +102,9 @@ def test_polars_vs_pandas_categorical_stats():
     assert result_polars.shape == result_pandas.shape
 
     # Variable names should be the same
-    assert result_polars["Var. N=10"].to_list() == result_pandas["Var. N=10"].to_list()
+    assert (
+        result_polars["Col (N=10)"].to_list() == result_pandas["Col (N=10)"].to_list()
+    )
 
     # Number of uniques should be the same
     assert result_polars["Uniques"].to_list() == result_pandas["Uniques"].to_list()
@@ -118,10 +122,10 @@ def test_polars_backend_with_nulls():
     result = make_stats_tbl(df, "num")
 
     # col_with_nulls should have 20% NA (2 out of 10)
-    assert result.filter(pl.col("Var. N=10") == "col_with_nulls")["NA%"][0] == 20
+    assert result.filter(pl.col("Col (N=10)") == "col_with_nulls")["NA%"][0] == 20
 
     # col_no_nulls should have 0% NA
-    assert result.filter(pl.col("Var. N=10") == "col_no_nulls")["NA%"][0] == 0
+    assert result.filter(pl.col("Col (N=10)") == "col_no_nulls")["NA%"][0] == 0
 
 
 def test_pandas_backend_with_nulls():
@@ -136,11 +140,11 @@ def test_pandas_backend_with_nulls():
     result = make_stats_tbl(df, "num")
 
     # col_with_nulls should have 20% NA (2 out of 10)
-    col_with_nulls_row = result.filter(pl.col("Var. N=10") == "col_with_nulls")
+    col_with_nulls_row = result.filter(pl.col("Col (N=10)") == "col_with_nulls")
     assert col_with_nulls_row["NA%"][0] == 20
 
     # col_no_nulls should have 0% NA
-    col_no_nulls_row = result.filter(pl.col("Var. N=10") == "col_no_nulls")
+    col_no_nulls_row = result.filter(pl.col("Col (N=10)") == "col_no_nulls")
     assert col_no_nulls_row["NA%"][0] == 0
 
 
@@ -162,8 +166,8 @@ def test_polars_backend_datetime():
     # Should have 2 rows (date_col and datetime_col)
     assert result.shape[0] == 2
 
-    # Should have columns: Var. N=10, NA%, Min, Max, Median
-    assert "Var. N=10" in result.columns
+    # Should have columns: Col (N=10), NA%, Min, Max, Median
+    assert "Col (N=10)" in result.columns
     assert "NA%" in result.columns
     assert "Min" in result.columns
     assert "Max" in result.columns
@@ -203,7 +207,7 @@ def test_polars_backend_boolean():
     assert result.shape[0] == 2
 
     # bool_col should be included
-    assert "bool_col" in result["Var. N=10"].to_list()
+    assert "bool_col" in result["Col (N=10)"].to_list()
 
 
 def test_pandas_backend_boolean():

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -6,12 +6,12 @@ from showstats.showstats import show_stats
 def test_show(sample_df, capsys):
     show_stats(sample_df)
     captured = capsys.readouterr()
-    assert "Var. N=500" in captured.out
+    assert "Col (N=500)" in captured.out
     assert "float_mean_2" in captured.out
     assert "float_min_-7" in captured.out
     show_stats(sample_df, "cat")
     captured = capsys.readouterr()
-    assert "Var. N=500" in captured.out
+    assert "Col (N=500)" in captured.out
     assert "float_mean_2" not in captured.out
     assert "float_min_-7" not in captured.out
     assert "str_col" in captured.out
@@ -19,7 +19,7 @@ def test_show(sample_df, capsys):
     assert "categorical_col" in captured.out
     show_stats(sample_df, "time")
     captured = capsys.readouterr()
-    assert "Var. N=500" in captured.out
+    assert "Col (N=500)" in captured.out
     assert "float_mean_2" not in captured.out
     assert "float_min_-7" not in captured.out
     assert "date_col" in captured.out
@@ -32,12 +32,12 @@ def test_show(sample_df, capsys):
 def test_namespace(sample_df, capsys):
     sample_df.stats.show()
     captured = capsys.readouterr()
-    assert "Var. N=500" in captured.out
+    assert "Col (N=500)" in captured.out
     assert "float_mean_2" in captured.out
     assert "float_min_-7" in captured.out
     sample_df.stats.show("cat")
     captured = capsys.readouterr()
-    assert "Var. N=500" in captured.out
+    assert "Col (N=500)" in captured.out
     assert "float_mean_2" not in captured.out
     assert "float_min_-7" not in captured.out
     assert "str_col" in captured.out

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -138,7 +138,7 @@ def test_single_columns():
     assert flt_table.stat_dfs["num"].shape == desired_shape
     assert flt_table.stat_dfs["num"].item(0, "Avg") == "1.6"
     assert flt_table.stat_dfs["num"].item(0, 1) == 0
-    assert flt_table.stat_dfs["num"].columns[0] == "Var. N=2"
+    assert flt_table.stat_dfs["num"].columns[0] == "Col (N=2)"
 
 
 def test_char_table():
@@ -168,7 +168,14 @@ def test_char_table():
     assert _table.stat_dfs["cat"].filter(col0 == "x3").item(0, "Top 3") == "C (4%)"
 
     assert stat_df.get_column(stat_df.columns[0]).to_list() == list(data.keys())
-    assert stat_df.columns == ["Var. N=26", "NA%", "Uniques", "Top 1", "Top 2", "Top 3"]
+    assert stat_df.columns == [
+        "Col (N=26)",
+        "NA%",
+        "Uniques",
+        "Top 1",
+        "Top 2",
+        "Top 3",
+    ]
 
 
 def test_long_variable_names_are_truncated():
@@ -201,8 +208,8 @@ def test_pandas(sample_df):
     # So we check shapes and most columns, but allow minor formatting differences
     assert _table_pandas.stat_dfs["num"].shape == _table_polars.stat_dfs["num"].shape
     assert (
-        _table_pandas.stat_dfs["num"]["Var. N=3"][0]
-        == _table_polars.stat_dfs["num"]["Var. N=3"][0]
+        _table_pandas.stat_dfs["num"]["Col (N=3)"][0]
+        == _table_polars.stat_dfs["num"]["Col (N=3)"][0]
     )
     assert (
         _table_pandas.stat_dfs["num"]["NA%"][0]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -171,6 +171,23 @@ def test_char_table():
     assert stat_df.columns == ["Var. N=26", "NA%", "Uniques", "Top 1", "Top 2", "Top 3"]
 
 
+def test_long_variable_names_are_truncated():
+    long_name = "this_is_a_really_really_long_variable_name_that_goes_on_and_on"
+    df = pl.DataFrame({long_name: [1, 2, 3], "short": [1.0, 2.0, 3.0]})
+
+    _table = _Table(df, "num")
+    _table.form_stat_df("num")
+    stat_df = _table.stat_dfs["num"]
+
+    names = stat_df.get_column(stat_df.columns[0]).to_list()
+    assert "short" in names
+    assert long_name not in names
+    truncated = next(n for n in names if n != "short")
+    assert len(truncated) == 30
+    assert truncated.endswith("…")
+    assert truncated.startswith(long_name[:29])
+
+
 def test_pandas(sample_df):
     tmp = pl.DataFrame({"a": [1, 2, 3], "b": ["A", "B", "C"]})
 


### PR DESCRIPTION
Closes #26. Split out of #36.

Two changes to the first column of the printed table.

## Truncate over-long names

Names longer than the table's width budget wrap onto a second, misaligned line and break the column layout:

```
 Var. N=5                                      NA%  Avg  SD    Min  Max  Median
 short                                         0    3.0  1.58  1.0  5.0  3.0
 this_is_a_really_really_long_variable_name_t  0    3.0  1.58  1    5    3.0
 hat_goes_on_and_on
```

Names over 30 characters are now truncated with an ellipsis. The limit is a module-level constant (`_MAX_VAR_NAME_LEN`) — happy to expose it as a parameter if you'd prefer.

## Rename the header to `Col (N=...)`

`Var.` reads as the standard abbreviation for *variance*, which is a poor ambiguity in a table that already reports `SD`. `Col` is unambiguous, and more accurate — these are columns of the input frame. The parentheses also separate the two facts the header carries: what the column holds, and how big the frame is.

Both changes together:

```
-Numerical columns--------------------------------------------------------------
 Col (N=3)                       NA%  Avg  SD   Min  Max  Median
 s                               0    2.0  1.0  1.0  3.0  2.0
 this_is_a_really_really_long_…  0    2.0  1.0  1    3    2.0
```

## Test plan

- [x] New test covers truncation, the ellipsis marker, and that short names are untouched
- [x] All 21 hardcoded header assertions across `test_show.py`, `test_backends.py` and `test_table.py` updated
- [x] Verified rendered output for the normal, truncated and large-N (scientific notation) paths
- [x] `pytest tests/` — 31 passed, 3 skipped (pre-existing pandas skips from #33, tracked in #43)
- [x] `ruff check .` / `ruff format --check .` clean

## Notes

- The README example output is updated by hand rather than re-rendered through Quarto (not available here) — worth a `quarto render` before release.
- Above 100k rows the header now reads `Col (N=1.50E+5)`. The scientific notation predates this PR; I left it alone to keep scope tight, but a thousands separator would read better for a row count and is lossy today (`123,456` renders as `1.23E+5`). Say the word and I'll open a separate PR.
- This PR and #46 both touch the README's example output, so whichever merges second will need a trivial conflict resolution there.
