### PR TITLE
Install narwhals in nox sessions and cover pyarrow input

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -12,7 +12,11 @@ def lint(session):
 @nox.session(name="python_versions", python=["3.8", "3.9", "3.10", "3.11", "3.12"])
 def test(session):
     session.install(
-        "pytest>=8.3.2", "polars>=0.20.21", "pandas>=1.5.3", "pyarrow>=10.0.0"
+        "pytest>=8.3.2",
+        "polars>=0.20.21",
+        "pandas>=1.5.3",
+        "pyarrow>=10.0.0",
+        "narwhals>=1.0.0",
     )
 
     session.run("pytest", "tests/")
@@ -27,5 +31,6 @@ def test_polars_versions(session, polars_version, pandas_version):
         f"polars=={polars_version}",
         f"pandas>={pandas_version}",
         "pyarrow>=10.0.0",
+        "narwhals>=1.0.0",
     )
     session.run("pytest", "tests/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,16 @@ def test_input_check(sample_df):
         )
 
 
+def test_input_check_pyarrow():
+    import pyarrow as pa
+
+    tbl = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    df = _check_input_maybe_try_transform(tbl)
+    assert isinstance(df, nw.DataFrame)
+    assert df.shape == (3, 2)
+    assert list(df.columns) == ["a", "b"]
+
+
 def test_mapping(sample_df):
     # Wrap in narwhals since _map_cols_and_funs_for_var_type expects narwhals DataFrame
     nw_df = nw.from_native(sample_df, eager_only=True)


### PR DESCRIPTION
Split out of #36. Two small test/build fixes.

**`noxfile.py`** — the nox sessions list their dependencies explicitly rather than installing from `dev-requirements.txt`, and were never updated when narwhals became a runtime dependency in #33. Every nox session therefore fails at import with `ModuleNotFoundError: No module named 'narwhals'`. GitHub Actions doesn't run nox (it installs from `dev-requirements.txt`), which is why CI stayed green and this went unnoticed.

**`tests/test_utils.py`** — adds coverage for pyarrow input. The whole point of #33 was accepting backends beyond polars and pandas, but no test exercised one. This asserts a `pa.table` is accepted and comes back as an `nw.DataFrame` with the right shape and columns.

## Test plan

- [x] `pytest tests/` — 31 passed, 3 skipped (pre-existing pandas skips from #33, tracked in #43)
- [x] `ruff check .` / `ruff format --check .` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_