### PR TITLE
Re-render README.md from README.qmd in CI

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -1,0 +1,54 @@
+name: Render README
+
+# README.md is generated from README.qmd. Its example output embeds real
+# showstats output, so it goes stale when either the source .qmd or the
+# package itself changes — hence the src/** trigger.
+on:
+  push:
+    branches: [main]
+    paths:
+      - README.qmd
+      - src/**
+      - .github/workflows/readme.yaml
+  workflow_dispatch:
+
+# Never let two renders race to push a commit.
+concurrency:
+  group: render-readme
+  cancel-in-progress: false
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          version: "1.6.39"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.9"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r dev-requirements.txt
+
+      - name: Render README.qmd
+        run: quarto render README.qmd
+
+      - name: Commit README.md if it changed
+        run: |
+          if git diff --quiet -- README.md; then
+            echo "README.md already up to date."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "Re-render README.md from README.qmd"
+          git push

--- a/README.md
+++ b/README.md
@@ -71,4 +71,5 @@ df.select("U", "int_col").stats.show()
 - Numbers with many digits are automatically converted to scientific
   notation.
 
-- Because **showstats** leverages polars effective parallelism, it\`s fast: \<1s for a 1,000,000 × 1,000 data frame, on a M1 MacBook
+- Because **showstats** leverages polars effective parallelism, it\`s
+  fast: \<1s for a 1,000,000 × 1,000 data frame, on a M1 MacBook

--- a/README.qmd
+++ b/README.qmd
@@ -35,7 +35,7 @@ show_stats(df, "cat")  # Other are num, time
 
 
 ```{python}
-# Importing **statsshow** adds the stats namespace
+# Importing showstats adds the stats namespace
 df.select("U", "int_col").stats.show()
 ```
 
@@ -46,5 +46,5 @@ df.select("U", "int_col").stats.show()
 
 - Numbers with many digits are automatically converted to scientific notation.
 
-- Because **showstats** leverages polars efficiency, it`s fast: <1 second for a 1,000,000 &times; 1,000 data frame, running on a M1 MacBook.
+- Because **showstats** leverages polars effective parallelism, it`s fast: <1s for a 1,000,000 &times; 1,000 data frame, on a M1 MacBook
  


### PR DESCRIPTION
Part of #49 (the action half — dataset half is separate, see below).

Adds `.github/workflows/readme.yaml`, which runs `quarto render README.qmd` and commits the result when it changes.

## The drift this found

`README.md` is generated from `README.qmd`, but nothing enforced it — and the two had **already diverged on `main`**:

| | `README.qmd` (source) | `README.md` (committed) |
|---|---|---|
| namespace comment | `Importing **statsshow** adds…` | `Importing showstats adds…` |
| performance note | "leverages polars efficiency… <1 second… running on a M1 MacBook" | "leverages polars effective parallelism… <1s… on a M1 MacBook" |

`README.md` was hand-edited in #32 without the source following. `statsshow` is a typo for the package name.

This matters for sequencing: **switching the workflow on without fixing the drift first would have regressed the README**, silently reintroducing the typo and reverting the better prose on the next push. So this PR ports the corrected prose back into `README.qmd` and re-renders. The only content change to `README.md` is Quarto re-wrapping one bullet.

## Workflow design

- **Triggers on `src/**` as well as `README.qmd`.** The example output embeds real `show_stats` output, so it goes stale when the *package* changes, not just when the prose does. This is the part that's easy to miss.
- **No infinite loop:** pushes made with `GITHUB_TOKEN` don't trigger new workflow runs, so the commit can't re-fire the job.
- **`concurrency` group** so two pushes can't race to commit.
- **No-ops cleanly** when the render produces no change, so it won't create empty commits.

## Verified locally

I installed Quarto 1.6.39 and actually ran this rather than writing it blind:

- [x] `quarto render README.qmd` succeeds against the repo's dev dependencies
- [x] **Render is idempotent** — two consecutive renders are byte-identical, so the job won't produce noise commits on every run. (The example data is seeded via `sample_df_`, so the statistics tables are deterministic.)
- [x] Post-fix, the rendered `README.md` matches the committed one apart from the one re-wrapped bullet
- [x] Workflow YAML parses; `pytest` 30 passed / 3 skipped; `ruff check .` clean

## Caveats

- If `main` is protected against direct pushes, the bot's push will fail and the job needs either an exemption or switching to open a PR instead. Happy to switch it if that's your setup.
- An alternative design is a **check-only** job that fails a PR when `README.md` is stale, rather than auto-committing to `main`. That keeps `main` push-clean but requires contributors to have Quarto installed locally — which, having just hit that myself, is a real friction. Say the word if you'd prefer it.
- The pinned Quarto version (`1.6.39`) will need occasional bumping; `release` is the alternative if you'd rather it float.

## The other half of #49

The issue also asks about an interesting public dataset. I've validated a good candidate — I'll follow up separately rather than bundle it here, since it rewrites the README example output and would collide with #45 and #46, which both touch those blocks. Details in a comment on #49.


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_