### PR TITLE
Make the README render job survive a concurrent merge (#51)

### DIFF
--- a/.github/workflows/readme.yaml
+++ b/.github/workflows/readme.yaml
@@ -12,10 +12,11 @@ on:
       - .github/workflows/readme.yaml
   workflow_dispatch:
 
-# Never let two renders race to push a commit.
+# Only the newest commit on main is worth rendering, so supersede any run
+# that is still working on an older one.
 concurrency:
   group: render-readme
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   render:
@@ -43,12 +44,31 @@ jobs:
 
       - name: Commit README.md if it changed
         run: |
-          if git diff --quiet -- README.md; then
-            echo "README.md already up to date."
-            exit 0
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add README.md
-          git commit -m "Re-render README.md from README.qmd"
-          git push
+
+          # main can advance while this job runs, which rejects the push. When
+          # that happens, re-render against the new tip rather than rebasing a
+          # render that may already be stale, then try again.
+          for attempt in 1 2 3; do
+            if git diff --quiet -- README.md; then
+              echo "README.md already up to date."
+              exit 0
+            fi
+
+            git add README.md
+            git commit -m "Re-render README.md from README.qmd"
+
+            if git push; then
+              echo "Pushed re-rendered README.md."
+              exit 0
+            fi
+
+            echo "Push rejected on attempt ${attempt}; re-rendering against the latest main."
+            git fetch origin main
+            git reset --hard origin/main
+            quarto render README.qmd
+          done
+
+          echo "::error::Could not push the re-rendered README.md after 3 attempts."
+          exit 1


### PR DESCRIPTION
Closes #51.

## The misalignment is already gone — but by luck

The shifted columns in the screenshot are fixed on `main` as of commit `c3f42d8`. I verified it rather than assuming: rendering `README.qmd` at current `main` produces a file byte-identical to the committed `README.md`.

The cause was mine. In #45 I renamed the header with `sed`, swapping the 10-character `Var. N=100` for the 11-character `Col (N=100)` without dropping a padding space — so every header sat one column right of its data. **Only the committed README was affected**; runtime output was always correct, because polars computes the padding itself.

## What actually needs fixing

The render job from #50 *did* catch this. Its run on the merge commit rendered the corrected README and committed it — `1 file changed, 6 insertions(+), 6 deletions(-)`, exactly the six header lines — and then:

```
! [rejected]  main -> main (fetch first)
error: failed to push some refs
```

#47 merged about a minute later and advanced `main` while the render was still running. The job died holding the only copy of the fix. `main` stayed broken until an unrelated merge happened to trigger a second run that won its race — which is the only reason #51 is fixed today. Without that coincidence the README would still be wrong.

So the bug isn't the alignment, it's that **the job that repairs the README has no way to survive `main` moving under it** — a ~90 second window that any two closely-spaced merges will hit.

## Fix

On rejection, re-render against the new tip and retry (3 attempts). Deliberately *not* a rebase or force-push: the render already produced is derived from the old source and may be stale relative to the new tip, so replaying it could overwrite a newer render with an older one. Re-rendering is the only correct recovery.

Concurrency also moves to `cancel-in-progress: true` — only the newest commit on `main` is worth rendering, so a superseded run should stop rather than push a stale result.

## Tested

I shipped a broken workflow once already here, so this one was exercised in a sandbox with a fake `quarto` and two clones racing a bare remote, rather than reasoned about:

| scenario | old script | new script |
|---|---|---|
| main advances mid-render | **push rejected, fix discarded** (reproduces the real failure) | recovers |
| …and the new tip is already correctly rendered | — | detects no diff, exits without a bogus commit |
| …and a diff still remains after rebasing | — | re-renders and pushes on attempt 2, ending with `README.md` matching the *newest* source |

The middle case is the one worth calling out: the job must not push its stale render over a newer one, and it doesn't.

`README.qmd` and `README.md` are untouched by this PR — they're already correct on `main`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_