### PR TITLE
Move Min and Max to the end of the table (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ show_stats(df)
 ```
 
     -Date and datetime columns------------------------------------------------------
-     Col (N=1461)  NA%  Min         Max         Median              
-     date          0    2012-01-01  2015-12-31  2013-12-31 00:00:00 
+     Col (N=1461)  NA%  Median               Min         Max        
+     date          0    2013-12-31 00:00:00  2012-01-01  2015-12-31 
     -Numerical columns--------------------------------------------------------------
-     Col (N=1461)   NA%  Avg    SD    Min   Max   Median 
-     precipitation  0    3.03   6.68  0.0   55.9  0.0    
-     temp_max       0    16.44  7.35  -1.6  35.6  15.6   
-     temp_min       0    8.23   5.02  -7.1  18.3  8.3    
-     wind           0    3.24   1.44  0.4   9.5   3.0    
+     Col (N=1461)   NA%  Avg    SD    Median  Min   Max  
+     precipitation  0    3.03   6.68  0.0     0.0   55.9 
+     temp_max       0    16.44  7.35  15.6    -1.6  35.6 
+     temp_min       0    8.23   5.02  8.3     -7.1  18.3 
+     wind           0    3.24   1.44  3.0     0.4   9.5  
     -Categorical columns------------------------------------------------------------
      Col (N=1461)  NA%  Uniques  Top 1       Top 2      Top 3    
      weather       0    5        rain (44%)  sun (44%)  fog (7%) 
@@ -42,9 +42,9 @@ show_stats(df.select("temp_max", "wind"))
 ```
 
     -Numerical columns--------------------------------------------------------------
-     Col (N=1461)  NA%  Avg    SD    Min   Max   Median 
-     temp_max      0    16.44  7.35  -1.6  35.6  15.6   
-     wind          0    3.24   1.44  0.4   9.5   3.0    
+     Col (N=1461)  NA%  Avg    SD    Median  Min   Max  
+     temp_max      0    16.44  7.35  15.6    -1.6  35.6 
+     wind          0    3.24   1.44  3.0     0.4   9.5  
 
 ``` python
 # Add extra quantiles for numerical columns

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `df.stats.show()` and `df.stats.make_tbl()`. The accessor was polars-only,
   which does not fit the narwhals direction (#53)
 
+### Changed
+
+- `Min` and `Max` now come last in the numerical and time tables, after
+  `Median` and any quantile columns — the central statistics lead and the
+  extremes close (#35)
+
 ### Added
 
 - `quantiles` argument on `show_stats`/`make_stats_tbl` to compute extra

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -392,15 +392,16 @@ class _Table:
                 ]
             else:
                 # Named stats keep their names; any requested quantiles are
-                # appended alongside them.
+                # appended alongside them. Min and Max sit last: they are the
+                # extremes, so the central statistics come first.
                 tail_cols = [
-                    pl.col("min").alias("Min"),
-                    pl.col("max").alias("Max"),
                     pl.col("median").alias("Median"),
                     *(
                         pl.col(_quantile_stat_name(q)).alias(_quantile_label(q))
                         for q in (self.quantiles or [])
                     ),
+                    pl.col("min").alias("Min"),
+                    pl.col("max").alias("Max"),
                 ]
             stat_df = stat_df.select(
                 pl.col("Variable").alias(name_var),
@@ -415,9 +416,9 @@ class _Table:
             stat_df = stat_df.select(
                 pl.col("Variable").alias(name_var),
                 pl.col("null_count").alias("NA%"),
+                pl.col("median").alias("Median"),
                 pl.col("min").alias("Min"),
                 pl.col("max").alias("Max"),
-                pl.col("median").alias("Median"),
             )
 
         if self.top_cols is not None:  # Put top_cols at front

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -236,10 +236,10 @@ def test_quantiles_fold_min_and_max():
         "NA%",
         "Avg",
         "SD",
+        "Median",
         "Min",
         "Max",
-        "Median",
-    ], "the default table must be unchanged when no quantiles are asked for"
+    ], "Min/Max come last; the central statistics lead"
 
     _table = _Table(df, "num", quantiles=[0.1, 0.9])
     _table.form_stat_df("num")
@@ -324,11 +324,11 @@ def test_fold_quantiles_false_keeps_named_columns():
         "NA%",
         "Avg",
         "SD",
-        "Min",
-        "Max",
         "Median",
         "Q10",
         "Q50",
+        "Min",
+        "Max",
     ]
 
 


### PR DESCRIPTION
Closes #35.

`Min` and `Max` sat between `SD` and `Median`, splitting the central statistics either side of the extremes. They now come last, so each row reads as summary → range:

```
before:  Col (N=100)  NA%  Avg   SD     Min   Max   Median
after:   Col (N=100)  NA%  Avg   SD     Median  Min   Max
```

The time table gets the same treatment, for consistency:

```
 Col (N=100)     NA%  Median      Min                  Max
 date_col        0    1755-07-20  1501-01-20           1996-04-09
```

## One judgement call

**The folded quantile sequence is left alone.** With `quantiles` requested and folding on, `Q0` *is* the min — and it has to lead for the run to stay in ascending order, which is the entire point of folding it in:

```
 Col (N=100)  NA%  Avg   SD     …  Q0  Q10   Q90   Q100
```

Moving `Q0` to the end would leave `Q100 Q10 Q90 Q0`-style ordering and undo the readability the fold was for. So `Min`/`Max` move to the end only where they are *named* columns: the default table, the time table, and `fold_quantiles=False`.

If you'd rather the folded sequence also put its endpoints last, say so and I'll change it — but I think ascending reads better there.

## Test plan

- [x] Two existing order assertions updated to the new expectation
- [x] Verified all four layouts by eye: default, time, folded quantiles, `fold_quantiles=False`
- [x] `pytest tests/` — 41 passed, 3 skipped
- [x] `ruff check .` / `ruff format --check .` clean; README re-rendered through Quarto

## Merge order

Touches `_table.py` and the README example, so it overlaps with #59 (`table_type` Literal, also `_table.py`) and #58 (namespace removal, also the README). Any order works; whichever lands later needs a trivial rebase.
