### PR TITLE
Add a PyPI publishing workflow (#56)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,79 @@
+name: Publish
+
+# Publishing is driven by GitHub Releases, so cutting a release is the single
+# deliberate action that ships a version — pushes to main never publish.
+#
+# The tag must match the version in pyproject.toml; the check-version job
+# enforces that, so a release tagged v0.1.0 cannot ship a 0.0.3 artifact.
+on:
+  release:
+    types: [published]
+  # Dry run: builds and uploads the artifacts without publishing anywhere.
+  workflow_dispatch:
+
+jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.9"
+
+      - name: Tag must match the version in pyproject.toml
+        if: github.event_name == 'release'
+        run: |
+          project_version=$(python -c "
+          import tomllib, pathlib
+          print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['project']['version'])
+          ")
+          tag="${GITHUB_REF_NAME#v}"
+          echo "pyproject version: ${project_version}"
+          echo "release tag:       ${GITHUB_REF_NAME} (normalised: ${tag})"
+          if [ "$project_version" != "$tag" ]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} does not match pyproject version ${project_version}. Bump pyproject.toml, or retag."
+            exit 1
+          fi
+
+  build:
+    needs: check-version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11.9"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Check metadata renders on PyPI
+        run: |
+          python -m pip install twine
+          python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    # Only a published release ships; workflow_dispatch stops after build.
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Required for PyPI trusted publishing — no API token is stored.
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Closes #56.

Adds `.github/workflows/publish.yaml`: build → verify → publish to PyPI, triggered by **publishing a GitHub Release**. Pushes to `main` never publish, so cutting a release is the single deliberate action that ships a version. Your existing tags (`v0.0.2`, `v0.0.3`) show the process is already tag-based, so this matches it.

## Three jobs

**`check-version`** refuses to publish when the release tag disagrees with `pyproject.toml`. This guards a failure mode that is silent and effectively permanent: tag `v0.1.0` while `pyproject` still says `0.0.3`, and you ship an artifact named `0.0.3` — which PyPI will not let you reupload or replace. It's a live risk right now, since #60 bumps the version and the two could easily get out of step.

**`build`** runs `python -m build` and `twine check dist/*`, then uploads the artifacts. `twine check` catches a README that fails to render on PyPI *before* the upload rather than after.

**`publish`** uses [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) via `pypa/gh-action-pypi-publish`. No API token is stored in the repository.

## Setup needed before the first release

Trusted publishing needs a one-time configuration — the workflow will fail until it's done:

1. On PyPI → *your project* → **Publishing** → add a GitHub publisher:
   - Owner `matthiaskaeding`, repository `showstats`, workflow `publish.yaml`, environment `pypi`
2. In repo **Settings → Environments**, create an environment named `pypi` (optionally with a required reviewer, which adds a manual approval gate before anything is uploaded)

If you'd rather use a stored `PYPI_API_TOKEN` instead, that's a two-line change — say so and I'll switch it.

## Tested

The parts that can be exercised locally, were:

- [x] `python -m build` produces a valid sdist and wheel from the current `pyproject.toml`
- [x] `twine check` passes on both artifacts (README metadata renders)
- [x] The version guard was run against four tag forms, since a shell string comparison is exactly where this kind of job goes wrong:

| tag | pyproject | result |
|---|---|---|
| `v0.1.0` | `0.0.3` | blocked ✓ |
| `v0.0.3` | `0.0.3` | allowed ✓ |
| `0.0.3` (no `v`) | `0.0.3` | allowed ✓ |
| `release-2024` | `0.0.3` | blocked ✓ |

- [x] Workflow YAML parses; `pytest` 41 passed / 3 skipped; `ruff check .` clean

`workflow_dispatch` is wired to build and `twine check` **without** publishing, so you can exercise the packaging path once without cutting a release.

## Note

`tomllib` is stdlib from Python 3.11 and the job pins 3.11.9, so the version check needs no extra dependency — this is unrelated to the package's own `requires-python = ">= 3.8"`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_