### PR TITLE
Set the in-development version to 0.1.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.0] - unreleased
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-version = "0.0.3"
+version = "0.1.0"
 readme = "README.md"
 requires-python = ">= 3.8"
 


### PR DESCRIPTION
Names the in-development version `0.1.0` instead of `Unreleased`.

```
## [0.1.0] - unreleased
```

## Why 0.1.0

Justified twice over under the usual 0.x convention (bump the middle number for features or breaking changes):

- the unreleased set already adds a feature — `quantiles` / `fold_quantiles` (#4)
- #58 removes the `.stats` namespace outright, which is breaking

Worth noting the breaking part isn't on `main` yet — it's still in #58 — but the feature alone already earns the bump, so the label holds whether or not #58 lands.

## pyproject moves with it

`pyproject.toml` goes `0.0.3` → `0.1.0` in the same commit. It's the single source of truth: `__version__` reads it through `importlib.metadata`, so there's no second constant to keep in sync.

This is safe to do now because releases are cut from tags (`v0.0.2`, `v0.0.3`) — nothing publishes until `v0.1.0` is tagged. It also matters for #60, whose `check-version` job **fails the release** if the tag and `pyproject` disagree; leaving `pyproject` at `0.0.3` while the changelog says `0.1.0` would block the first release until someone noticed.

## Note on format

`## [0.1.0] - unreleased` departs slightly from Keep a Changelog, which reserves `## [Unreleased]` for pending work and dates a version only once shipped. Naming the in-development version was the explicit request, and it reads unambiguously; swap the `- unreleased` suffix for a date at release time.

Unrelated but adjacent: the existing `## [0.0.3]` heading has no date, where `0.0.2` and `0.0.1` do. Left alone here rather than folded into this change.

## Test plan

- [x] `pytest tests/` — 41 passed, 3 skipped; `ruff check .` clean
- [x] Confirmed no other file hardcodes the version (`__version__` derives from package metadata)


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_