### PR TITLE
Use absolute imports, and have ruff enforce it (#63)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,14 @@ pandas = ["pandas>=1.5.3", "pyarrow>=10.0.0"]
 [tool.ruff]
 extend-include = ["*.ipynb"]
 
+[tool.ruff.lint]
+# TID252 flags relative imports, so the absolute-import rule is enforced by
+# the linter rather than relying on review to catch a `from .mod import x`.
+extend-select = ["TID252"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
 [tool.pytest.ini_options]
 pythonpath = ["src"]
 

--- a/src/showstats/__init__.py
+++ b/src/showstats/__init__.py
@@ -1,6 +1,6 @@
 from importlib.metadata import PackageNotFoundError, version
 
-from .showstats import make_stats_tbl, show_stats
+from showstats.showstats import make_stats_tbl, show_stats
 
 try:
     __version__ = version("showstats")


### PR DESCRIPTION
Closes #63.

`src/showstats/__init__.py` held the only relative import in the package:

```diff
- from .showstats import make_stats_tbl, show_stats
+ from showstats.showstats import make_stats_tbl, show_stats
```

## Enforced rather than just fixed

The issue states a **rule**, not a one-off defect — and a rule nothing checks drifts back the first time someone types `from .`. So this also switches the linter on:

```toml
[tool.ruff.lint]
extend-select = ["TID252"]

[tool.ruff.lint.flake8-tidy-imports]
ban-relative-imports = "all"
```

`extend-select` rather than `select`, so ruff's defaults (`E4`, `E7`, `E9`, `F`) stay in place instead of being silently replaced.

I verified the rule actually fires rather than assuming it — reintroducing the relative form fails lint:

```
src/showstats/__init__.py:3:1: TID252 Prefer absolute imports over relative imports
```

and the absolute form passes clean. Worth checking, since a lint rule that's configured but inert is worse than none — it looks like coverage while providing nothing.

## Test plan

- [x] `pytest tests/` — 42 passed, 3 skipped
- [x] `ruff check .` / `ruff format --check .` clean under the pinned `ruff==0.5.6`
- [x] Confirmed TID252 flags a reintroduced relative import and passes on the absolute one
- [x] No other relative imports exist in `src/` or `tests/`


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_