### PR TITLE
Fix median on non-numeric columns for non-polars backends (#43)

### DIFF
--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -130,6 +130,24 @@ def _truncate_long_strings(expr: pl.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> p
     )
 
 
+def _median_expr(var: str, dtype) -> "nw.Expr":
+    """Median of a column, for dtypes some backends refuse to take it on.
+
+    polars computes median() directly for booleans and datetimes, but the
+    pandas backend raises `median operation not supported for non-numeric
+    input type`. Casting to an integer, taking the median there and casting
+    back produces the same answer on every backend — for datetimes the cast
+    goes through the column's own dtype, so the time unit round-trips
+    correctly rather than being assumed.
+    """
+    col = nw.col(var)
+    if dtype == nw.Boolean:
+        return col.cast(nw.Int8).median()
+    if dtype == nw.Date or dtype == nw.Datetime or str(dtype).startswith("Datetime"):
+        return col.cast(nw.Int64).median().cast(dtype)
+    return col.median()
+
+
 def _map_table_type_to_var_types(table_type):
     """Maps table type to var types"""
     if table_type == "all":
@@ -200,6 +218,7 @@ class _Table:
                 funs_map[var_type] = funs_vt
                 stat_names_map[var_type] = []
         self.funs_map = funs_map
+        schema = df.schema
         expressions = []
         sep = "____"
         for vt in vars_map:
@@ -218,6 +237,8 @@ class _Table:
                         # Q100 == max. polars' own default of "nearest" would
                         # make Q50 disagree with the Median column.
                         expr = col.quantile(q, interpolation="linear").alias(stat_name)
+                    elif function == "median":
+                        expr = _median_expr(var, schema[var]).alias(stat_name)
                     else:
                         expr = getattr(nw.col(var), function)().alias(stat_name)
                     expressions.append(expr)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,7 +4,6 @@ Tests to verify showstats works correctly with different dataframe backends.
 
 import pandas as pd
 import polars as pl
-import pytest
 from showstats import show_stats
 from showstats.showstats import make_stats_tbl
 
@@ -176,9 +175,20 @@ def test_polars_backend_datetime():
 
 def test_pandas_backend_datetime():
     """Test pandas backend with datetime columns"""
-    # Note: pandas datetime median is not supported in current narwhals version
-    # Skip this test for now
-    pytest.skip("Pandas datetime median not supported in narwhals")
+    df = pd.DataFrame(
+        {"datetime_col": pd.date_range("2020-01-01", periods=10, freq="D")}
+    )
+
+    result = make_stats_tbl(df, "time")
+
+    assert result is not None
+    assert "Median" in result.columns
+    # The median of ten consecutive days is midday on the fifth. Getting this
+    # right is what the Int64 round-trip in _median_expr is for: a wrong time
+    # unit would silently land in 1970.
+    assert result.item(0, "Median").startswith("2020-01-05 12:00:00")
+    assert result.item(0, "Min").startswith("2020-01-01")
+    assert result.item(0, "Max").startswith("2020-01-10")
 
 
 def test_polars_backend_boolean():
@@ -230,14 +240,14 @@ def test_pandas_backend_boolean():
         }
     )
 
-    # Note: pandas boolean median may have compatibility issues in narwhals
-    # Just test that it doesn't crash
-    try:
-        result = make_stats_tbl(df, "num")
-        assert result is not None
-        assert result.shape[0] >= 1
-    except Exception:
-        pytest.skip("Pandas boolean type compatibility issue")
+    result = make_stats_tbl(df, "num")
+
+    assert result is not None
+    assert result.shape[0] >= 1
+    # Five True out of ten, so the median of the boolean column is 0.5 —
+    # the same value polars reports for median() on a boolean.
+    bool_row = result.filter(pl.col(result.columns[0]) == "bool_col")
+    assert bool_row.item(0, "Median") == "0.5"
 
 
 def test_polars_backend_all_types():
@@ -270,13 +280,9 @@ def test_pandas_backend_all_types():
         }
     )
 
-    # Should not raise any errors
-    # Note: Some type detection may differ slightly between backends
-    try:
-        show_stats(df, "all")
-    except Exception as e:
-        # If it fails, it should be a known compatibility issue
-        pytest.skip(f"Pandas compatibility issue: {e}")
+    # Must not raise: this mixes the two dtypes whose median used to fail on
+    # non-polars backends (datetime and boolean) with the ones that never did.
+    show_stats(df, "all")
 
 
 def test_backend_with_empty_categorical():


### PR DESCRIPTION
Closes #43.

## This turned out to be a real bug, not a test problem

The three skips in `test_backends.py` were filed as separate compatibility notes. They share **one root cause**:

```
InvalidOperationError: `median` operation not supported for non-numeric input type.
```

`median()` on a **boolean or datetime** column raises on the pandas backend, where polars computes it directly. So `show_stats` simply **did not work** for a pandas frame containing a datetime or boolean column — a fairly ordinary frame.

The skips hid that. Two of them were `try/except Exception: pytest.skip(...)`, which pass whether the code works or not, so a total failure of the pandas path was reported as a skip. On `main` today, all three of these raise:

```python
show_stats(pd.DataFrame({"d": pd.date_range("2020-01-01", periods=10)}), "time")
show_stats(pd.DataFrame({"b": [True, False] * 5, "i": range(10)}), "num")
show_stats(pd.DataFrame({... datetime + bool + str + int ...}), "all")
```

## Fix

`_median_expr` casts to an integer, takes the median there, and casts back.

The datetime case has a trap worth naming: the integer is in the column's own time unit, so the cast back **must go through the column's dtype** rather than assume nanoseconds. I got this wrong first time and landed on `1970-01-19`. Casting via `schema[var]` gives `2020-01-05 12:00:00` on pandas and polars alike.

Booleans cast to `Int8`, which yields `0.5` for five True out of ten — the same value polars reports.

**polars output is unchanged.** Verified the two backends now agree on `Avg`, `SD` and `Median` for the same data.

## Test plan

- [x] All three tests now assert **real values** rather than skipping — the datetime median is midday on the fifth of ten consecutive days (which a wrong time unit would fail), and the boolean median is `0.5`
- [x] The `try/except: skip` blocks are gone, so these can no longer pass while broken
- [x] **Suite reports `45 passed` with zero skips** — previously `42 passed, 3 skipped`
- [x] Confirmed polars output byte-identical before and after
- [x] `ruff check .` / `ruff format --check .` clean

## Note

This removes the last of the "load-bearing skip count" I flagged when filing #43. Nothing in the suite now passes vacuously.


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_