### PR TITLE
Lint via the ruff action, pinned to the latest stable ruff (0.16.0)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,10 +21,10 @@ jobs:
       - name: Lint
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.5.6"
+          version: "0.16.0"
 
       - name: Check formatting
         uses: astral-sh/ruff-action@v3
         with:
-          version: "0.5.6"
+          version: "0.16.0"
           args: "format --check"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -13,16 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v6
+      # ruff is a standalone tool, not a project dependency, so this job does
+      # not sync the dev environment just to lint. The version is pinned here
+      # and also asserted by `required-version` in pyproject.toml, so the two
+      # cannot drift apart quietly — a mismatch fails the run rather than
+      # silently linting under different rules.
+      - name: Lint
+        uses: astral-sh/ruff-action@v3
         with:
-          enable-cache: true
+          version: "0.5.6"
 
-      # ruff's version comes from the dev group in pyproject.toml, so it is
-      # pinned in exactly one place rather than repeated here.
-      - name: Install dependencies
-        run: uv sync --group dev
-
-      - name: Run Ruff
-        run: |
-          uv run ruff check .
-          uv run ruff format --check .
+      - name: Check formatting
+        uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.5.6"
+          args: "format --check"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Must match required-version in pyproject.toml, or ruff refuses to run.
-    rev: v0.5.6
+    rev: v0.16.0
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.0
+    # Must match required-version in pyproject.toml, or ruff refuses to run.
+    rev: v0.5.6
     hooks:
       - id: ruff
         types_or: [python, pyi, jupyter]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,12 +52,13 @@ uv build             # sdist + wheel
   `uv sync` after changing dependencies and commit the updated lock.
 - `.python-version` pins the interpreter (3.11.9) so CI does not silently
   drift to a newer Python; `uv` provisions it automatically.
-- Lint/format uses `ruff==0.5.6`. A newer ruff enables extra rules (e.g.
-  `RUF013`, `FA100`) that aren't part of this project's lint gate and would
-  produce false positives, so `required-version = "==0.5.6"` in
-  `[tool.ruff]` makes ruff refuse to run under any other version — however
-  it's invoked. If you bump it, update all three: `required-version`, the
-  dev group, and `rev:` in `.pre-commit-config.yaml`. CI lints via
+- Lint/format uses `ruff==0.16.0`. `required-version = "==0.16.0"` in
+  `[tool.ruff]` makes ruff refuse to run under any other version, however
+  it's invoked — ruff's default rule set grows between releases, so a
+  mismatch lints under different rules than CI enforces. Bumping it means
+  updating **four** places: `required-version`, the `dev` group, `rev:` in
+  `.pre-commit-config.yaml`, and `version:` in `.github/workflows/lint.yaml`
+  — and then fixing whatever the new defaults flag. CI lints via
   `astral-sh/ruff-action` rather than syncing the dev environment, since
   ruff is a standalone tool.
 - `README.md` is generated from `README.qmd` via Quarto: `uv run quarto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,10 +52,14 @@ uv build             # sdist + wheel
   `uv sync` after changing dependencies and commit the updated lock.
 - `.python-version` pins the interpreter (3.11.9) so CI does not silently
   drift to a newer Python; `uv` provisions it automatically.
-- Lint/format uses `ruff==0.5.6`, pinned in the dev group — a newer ruff
-  enables extra rules (e.g. `RUF013`, `FA100`) that aren't part of this
-  project's lint gate and will produce false positives. Running it through
-  `uv run` is what guarantees you get the pinned one.
+- Lint/format uses `ruff==0.5.6`. A newer ruff enables extra rules (e.g.
+  `RUF013`, `FA100`) that aren't part of this project's lint gate and would
+  produce false positives, so `required-version = "==0.5.6"` in
+  `[tool.ruff]` makes ruff refuse to run under any other version — however
+  it's invoked. If you bump it, update all three: `required-version`, the
+  dev group, and `rev:` in `.pre-commit-config.yaml`. CI lints via
+  `astral-sh/ruff-action` rather than syncing the dev environment, since
+  ruff is a standalone tool.
 - `README.md` is generated from `README.qmd` via Quarto: `uv run quarto
   render README.qmd`. `uv run` matters here — it puts the project
   environment on `PATH` so Quarto's jupyter engine uses the synced

--- a/docs/timing.ipynb
+++ b/docs/timing.ipynb
@@ -13,6 +13,7 @@
     "sys.path.append(\"../src/\")\n",
     "sys.path.append(\"../tests/\")\n",
     "from conftest import sample_df_\n",
+    "\n",
     "from showstats.showstats import show_stats  # noqa"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ dev = [
 ]
 
 [tool.ruff]
+# Ruff refuses to run under any other version. A newer ruff enables extra
+# rules this project is not configured for, so a version mismatch — from CI,
+# a pre-commit hook or a stray global install — fails loudly instead of
+# producing findings that do not reflect the project's lint gate.
+required-version = "==0.5.6"
 extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,16 +36,16 @@ dev = [
   "polars>=0.20.23",
   "pyarrow>=17.0.0",
   "pytest==8.3.2",
-  "ruff==0.5.6",
+  "ruff==0.16.0",
   "twine>=5.1.1",
 ]
 
 [tool.ruff]
-# Ruff refuses to run under any other version. A newer ruff enables extra
-# rules this project is not configured for, so a version mismatch — from CI,
-# a pre-commit hook or a stray global install — fails loudly instead of
-# producing findings that do not reflect the project's lint gate.
-required-version = "==0.5.6"
+# Ruff refuses to run under any other version. Its default rule set grows
+# between releases, so a mismatch — from CI, a pre-commit hook or a stray
+# global install — would lint under different rules than the project is
+# configured for. Failing loudly beats findings nobody can reproduce.
+required-version = "==0.16.0"
 extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]

--- a/src/showstats/__init__.py
+++ b/src/showstats/__init__.py
@@ -11,4 +11,4 @@ finally:
     del PackageNotFoundError
 
 
-__all__ = ["show_stats", "make_stats_tbl"]
+__all__ = ["make_stats_tbl", "show_stats"]

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 import warnings
-from typing import Iterable, Literal, Tuple
+from typing import Iterable, Literal
 
 import narwhals as nw
 import polars as pl
@@ -90,7 +92,7 @@ def _quantile_label(q: float) -> str:
     return f"Q{pct_str}"
 
 
-def _map_funs_to_var_type(var_type, quantiles: Iterable = None) -> Tuple[str]:
+def _map_funs_to_var_type(var_type, quantiles: Iterable | None = None) -> tuple[str]:
     if var_type in ("num_float", "num_int", "num_bool"):
         funs = ["null_count", "mean", "std", "median", "min", "max"]
         if quantiles:
@@ -105,8 +107,8 @@ def _map_funs_to_var_type(var_type, quantiles: Iterable = None) -> Tuple[str]:
 
 
 def _map_cols_and_funs_for_var_type(
-    df, var_type, quantiles: Iterable = None
-) -> Tuple[str]:
+    df, var_type, quantiles: Iterable | None = None
+) -> tuple[str]:
     cols = _get_cols_for_var_type(df, var_type)
     if len(cols) == 0:
         return None, None
@@ -130,7 +132,7 @@ def _truncate_long_strings(expr: pl.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> p
     )
 
 
-def _median_expr(var: str, dtype) -> "nw.Expr":
+def _median_expr(var: str, dtype) -> nw.Expr:
     """Median of a column, for dtypes some backends refuse to take it on.
 
     polars computes median() directly for booleans and datetimes, but the
@@ -169,8 +171,8 @@ class _Table:
         self,
         df: IntoDataFrame,
         table_type: TableType,
-        top_cols: Iterable = None,
-        quantiles: Iterable = None,
+        top_cols: Iterable | None = None,
+        quantiles: Iterable | None = None,
         fold_quantiles: bool = True,
     ):
         df = _check_input_maybe_try_transform(df)
@@ -221,9 +223,9 @@ class _Table:
         schema = df.schema
         expressions = []
         sep = "____"
-        for vt in vars_map:
+        for vt, vars_vt in vars_map.items():
             functions_vt = funs_map[vt]
-            for var in vars_map[vt]:
+            for var in vars_vt:
                 for function in functions_vt:
                     stat_name = f"{var}{sep}{function}"
                     if function.startswith(QUANTILE_PREFIX):
@@ -354,7 +356,7 @@ class _Table:
                 row = {}
                 for i, dd in enumerate(freq_list):
                     val, count = dd[var_name], dd["count"]
-                    row[f"Top {i+1}"] = f"{val} ({count / self.num_rows:.0%})"
+                    row[f"Top {i + 1}"] = f"{val} ({count / self.num_rows:.0%})"
                 data.append(row)
             right = pl.DataFrame(data).fill_null("")
             df = df.select(

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -1,5 +1,7 @@
 # Central functions for table making
-from typing import List, Union, get_args
+from __future__ import annotations
+
+from typing import get_args
 
 from narwhals.typing import IntoDataFrame
 
@@ -9,8 +11,8 @@ from showstats._table import TableType, _Table
 def show_stats(
     df: IntoDataFrame,
     table_type: TableType = "all",
-    top_cols: Union[List[str], str, None] = None,
-    quantiles: Union[List[float], None] = None,
+    top_cols: list[str] | str | None = None,
+    quantiles: list[float] | None = None,
     fold_quantiles: bool = True,
 ) -> None:
     """
@@ -19,10 +21,10 @@ def show_stats(
 
     Args:
         df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
-        top_cols (Union[List[str], str, None], optional): Column or list of columns
+        top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         table_type (str): All variables (default) = "num" or categorical = "cat"
-        quantiles (Union[List[float], None], optional): Extra quantiles (values in
+        quantiles (list[float] | None, optional): Extra quantiles (values in
             [0, 1]) to compute for numerical columns, shown as extra "Q<pct>"
             columns. Defaults to None.
         fold_quantiles (bool, optional): When quantiles are given, relabel Min,
@@ -56,8 +58,8 @@ def show_stats(
 def make_stats_tbl(
     df: IntoDataFrame,
     table_type: TableType = "num",
-    top_cols: Union[List[str], str, None] = None,
-    quantiles: Union[List[float], None] = None,
+    top_cols: list[str] | str | None = None,
+    quantiles: list[float] | None = None,
     fold_quantiles: bool = True,
 ) -> None:
     """
@@ -66,10 +68,10 @@ def make_stats_tbl(
 
     Args:
         df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
-        top_cols (Union[List[str], str, None], optional): Column or list of columns
+        top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         type (str): All variables (default) = "num" or categorical = "cat"
-        quantiles (Union[List[float], None], optional): Extra quantiles (values in
+        quantiles (list[float] | None, optional): Extra quantiles (values in
             [0, 1]) to compute for numerical columns, shown as extra "Q<pct>"
             columns. Defaults to None.
         fold_quantiles (bool, optional): When quantiles are given, relabel Min,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime
 
 import polars as pl
@@ -8,10 +10,10 @@ from numpy import random as np_random
 def sample_series(
     seed: int = 1,
     n: int = 100,
-    min: float = None,
-    max: float = None,
-    std: float = None,
-    mean: float = None,
+    min: float | None = None,
+    max: float | None = None,
+    std: float | None = None,
+    mean: float | None = None,
 ) -> pl.Series:
     """
     Samples a pl.Series with known moments.
@@ -73,9 +75,13 @@ def sample_datetimes(
     return (
         pl.DataFrame(pl.Series("random_seconds", random_seconds))
         .select(
-            pl.lit(datetime(start_date.year, start_date.month, start_date.day)).alias(
-                name
-            )
+            # naive on purpose: a tz-aware literal would change the column's
+            # dtype and so what the tests are asserting about
+            pl.lit(
+                datetime(  # noqa: DTZ001
+                    start_date.year, start_date.month, start_date.day
+                )
+            ).alias(name)
             + pl.duration(seconds=pl.col("random_seconds"))
         )
         .get_column(name)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,6 +4,7 @@ Tests to verify showstats works correctly with different dataframe backends.
 
 import pandas as pd
 import polars as pl
+
 from showstats import show_stats
 from showstats.showstats import make_stats_tbl
 

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from showstats.showstats import make_stats_tbl
 
 

--- a/tests/test_scientific_conversion.py
+++ b/tests/test_scientific_conversion.py
@@ -1,4 +1,5 @@
 import polars as pl
+
 from showstats._utils import convert_df_scientific
 
 

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -1,5 +1,6 @@
 import polars as pl
 import pytest
+
 from showstats.showstats import show_stats
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -2,6 +2,7 @@ import warnings
 
 import polars as pl
 import pytest
+
 from showstats._table import _WARNED_ONCE, _Table
 
 
@@ -95,9 +96,6 @@ def test_that_statistics_are_correct(sample_df):
     assert stat_df.filter(var_0 == "float_std_2").item(0, "SD") == "2.0"
     assert stat_df.filter(var_0 == "float_min_-7").item(0, "Min") == "-7.0"
     assert stat_df.filter(var_0 == "float_max_17").item(0, "Max") == "17.0"
-
-
-1
 
 
 def test_top_cols(sample_df):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,22 @@
 import narwhals as nw
 import polars as pl
 import pytest
+
 from showstats._table import (
     _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
 )
+
+
+@pytest.mark.parametrize("bad", [1, 1.0, None, [], {}, {"a": []}])
+def test_input_check_rejects_non_frames(bad):
+    """Each of these must raise — none is a narwhals-native frame.
+
+    These used to sit in a single `pytest.raises(Exception)` block, where only
+    the first line ever ran: the rest were unreachable once it raised.
+    """
+    with pytest.raises(TypeError):
+        _check_input_maybe_try_transform(bad)
 
 
 def test_input_check(sample_df):
@@ -12,17 +24,8 @@ def test_input_check(sample_df):
     # Now returns a narwhals DataFrame
     assert isinstance(df2, nw.DataFrame)
     assert df2.shape == sample_df.shape
-    with pytest.raises(Exception):
-        # All of those are wrong inputs
-        _check_input_maybe_try_transform(1)
-        _check_input_maybe_try_transform(1.0)
-        _check_input_maybe_try_transform(None)
-        _check_input_maybe_try_transform([])
-        _check_input_maybe_try_transform(dict())
-        _check_input_maybe_try_transform(dict(a=[]))
-
     # Test with valid dict input (convert through polars first)
-    result2 = _check_input_maybe_try_transform(pl.DataFrame(dict(x=[1, 2, 3])))
+    result2 = _check_input_maybe_try_transform(pl.DataFrame({"x": [1, 2, 3]}))
     assert isinstance(result2, nw.DataFrame)
 
     sample_df_pandas = sample_df.to_pandas()

--- a/uv.lock
+++ b/uv.lock
@@ -1156,7 +1156,7 @@ version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+    { name = "typing-extensions", version = "4.16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -5715,27 +5715,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.5.6"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f7/69/96766da2cdb5605e6a31ef2734aff0be17901cefb385b885c2ab88896d76/ruff-0.5.6.tar.gz", hash = "sha256:07c9e3c2a8e1fe377dd460371c3462671a728c981c3205a5217291422209f642", size = 2444466, upload-time = "2024-08-02T15:53:00.099Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/54/af603686de0e9ba6c1798bd83d335e345e7c9ce4deed95a1071448bb6563/ruff-0.5.6-py3-none-linux_armv6l.whl", hash = "sha256:a0ef5930799a05522985b9cec8290b185952f3fcd86c1772c3bdbd732667fdcd", size = 9543715, upload-time = "2024-08-02T15:51:36.229Z" },
-    { url = "https://files.pythonhosted.org/packages/81/86/b22d250e1be2dcd11c749817d0cfe8be37efce6e6862c92ea037bedf6df9/ruff-0.5.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b652dc14f6ef5d1552821e006f747802cc32d98d5509349e168f6bf0ee9f8f42", size = 8662814, upload-time = "2024-08-02T15:51:42.686Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/e2/f97c58797fac1c7dd8226becfed55056fa7bbfb6d9c2e93900f2a27b540e/ruff-0.5.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:80521b88d26a45e871f31e4b88938fd87db7011bb961d8afd2664982dfc3641a", size = 8230427, upload-time = "2024-08-02T15:51:47.381Z" },
-    { url = "https://files.pythonhosted.org/packages/24/70/9f00cf1e2b50476751808ac6ebbfaa6dab3abab5514058f6bbca28a790bc/ruff-0.5.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9bc8f328a9f1309ae80e4d392836e7dbc77303b38ed4a7112699e63d3b066ab", size = 9976713, upload-time = "2024-08-02T15:51:52.136Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/02/309b171d867d819b7c76c46489597341ce85d70fefa05102a95130440005/ruff-0.5.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4d394940f61f7720ad371ddedf14722ee1d6250fd8d020f5ea5a86e7be217daf", size = 9345335, upload-time = "2024-08-02T15:51:56.896Z" },
-    { url = "https://files.pythonhosted.org/packages/37/42/74b84b97815a0b940f1438ff554ead1405d2556ff8e2da58d3c3068a2093/ruff-0.5.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:111a99cdb02f69ddb2571e2756e017a1496c2c3a2aeefe7b988ddab38b416d36", size = 10140380, upload-time = "2024-08-02T15:52:01.612Z" },
-    { url = "https://files.pythonhosted.org/packages/47/0c/705b979fe814498dfc3977bcdbf8c47059d2ed37b1c2128f1b77612eea82/ruff-0.5.6-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:e395daba77a79f6dc0d07311f94cc0560375ca20c06f354c7c99af3bf4560c5d", size = 10853490, upload-time = "2024-08-02T15:52:06.931Z" },
-    { url = "https://files.pythonhosted.org/packages/56/f1/400cc9a533fadba676783a2116526d1c26063d3228105bc75fa1c32a092b/ruff-0.5.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c476acb43c3c51e3c614a2e878ee1589655fa02dab19fe2db0423a06d6a5b1b6", size = 10425500, upload-time = "2024-08-02T15:52:12.603Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/cd/f2cf6bc23a4293e3f8c365138f7279eea9179d1c4d3e09546d64daea40da/ruff-0.5.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e2ff8003f5252fd68425fd53d27c1f08b201d7ed714bb31a55c9ac1d4c13e2eb", size = 11407463, upload-time = "2024-08-02T15:52:17.401Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/cc/227428f39f8834d281b6d18f84f53e08a840ed63dec259e5e5e502284cec/ruff-0.5.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c94e084ba3eaa80c2172918c2ca2eb2230c3f15925f4ed8b6297260c6ef179ad", size = 10160402, upload-time = "2024-08-02T15:52:22.406Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/61/218890d960ca146d3822e981a34834995081f3b741b82ca2585fd5ebc521/ruff-0.5.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1f77c1c3aa0669fb230b06fb24ffa3e879391a3ba3f15e3d633a752da5a3e670", size = 9971344, upload-time = "2024-08-02T15:52:27.613Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/20/bd444745ff7b51e497332ecf3f550bb62871dd24d61960997049fdbed268/ruff-0.5.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f908148c93c02873210a52cad75a6eda856b2cbb72250370ce3afef6fb99b1ed", size = 9417963, upload-time = "2024-08-02T15:52:32.164Z" },
-    { url = "https://files.pythonhosted.org/packages/30/03/69b6d3735f284d93324ca31e36316574501130393f1a8e328a74775f4fb5/ruff-0.5.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:563a7ae61ad284187d3071d9041c08019975693ff655438d8d4be26e492760bd", size = 9769870, upload-time = "2024-08-02T15:52:37.403Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/19/1c86dc40abef457124bb4abf90c68688eb2c7f9944903240c3b93d511360/ruff-0.5.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:94fe60869bfbf0521e04fd62b74cbca21cbc5beb67cbb75ab33fe8c174f54414", size = 10229991, upload-time = "2024-08-02T15:52:42.415Z" },
-    { url = "https://files.pythonhosted.org/packages/65/a7/60a19f3cfccdea5815bc31971f523f5b2ecd08162b05d1a0d5b8c37dff59/ruff-0.5.6-py3-none-win32.whl", hash = "sha256:e6a584c1de6f8591c2570e171cc7ce482bb983d49c70ddf014393cd39e9dfaed", size = 7789030, upload-time = "2024-08-02T15:52:46.288Z" },
-    { url = "https://files.pythonhosted.org/packages/27/c6/b51987072bba4a56537b6fc7036d9bf0694a9de6cceddaa0761475658632/ruff-0.5.6-py3-none-win_amd64.whl", hash = "sha256:d7fe7dccb1a89dc66785d7aa0ac283b2269712d8ed19c63af908fdccca5ccc1a", size = 8690520, upload-time = "2024-08-02T15:52:51.595Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/b1/712801cf487fd78554029b02f980e24531f5994e2bf79b7ac55c1659dd52/ruff-0.5.6-py3-none-win_arm64.whl", hash = "sha256:57c6c0dd997b31b536bff49b9eee5ed3194d60605a4427f735eeb1f9c1b8d264", size = 8101938, upload-time = "2024-08-02T15:52:56.459Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -5890,7 +5890,7 @@ dev = [
     { name = "polars", specifier = ">=0.20.23" },
     { name = "pyarrow", specifier = ">=17.0.0" },
     { name = "pytest", specifier = "==8.3.2" },
-    { name = "ruff", specifier = "==0.5.6" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "twine", specifier = ">=5.1.1" },
 ]
 


### PR DESCRIPTION
Follow-up to #70, which merged before these two changes were made — so they never reached `main`. Same work, on a fresh branch off current `main`.

## 1. Lint without syncing the dev environment

`main` currently runs `uv sync --group dev && uv run ruff`, which installs jupyter, pandas and pyarrow purely to lint. ruff is a standalone tool, not a project dependency:

```yaml
- uses: astral-sh/ruff-action@v3
  with:
    version: "0.16.0"

- uses: astral-sh/ruff-action@v3
  with:
    version: "0.16.0"
    args: "format --check"
```

Chose the dedicated action over `uv tool run` because it caches ruff and annotates findings inline on the PR. Two invocations rather than one action plus a bare `ruff format --check`, so nothing depends on the action leaving ruff on `PATH` for a later step.

## 2. Latest stable ruff — which is a real upgrade, not a number

Ruff's **default rule set has grown substantially** since 0.5.6. Confirmed with `--isolated`, so no project config is involved:

| ruff | findings on this codebase (config ignored) |
|---|---|
| 0.5.6 | **0** |
| 0.16.0 | **37** |

All fixed rather than selected back out:

- **FA100 / RUF013** — `from __future__ import annotations`, implicit optionals made explicit (`Iterable = None` → `Iterable | None = None`). The future import also lets signatures read `list[str] | str | None` while `requires-python` is still 3.8.
- **I001 / RUF022** — import and `__all__` ordering
- **PLC0206** — iterate `vars_map.items()` rather than keying back in
- **C408** — `dict()` → `{}`
- **B018** — a stray `1` expression statement sitting between two tests

### B017 was a real bug

This block only ever executed its first line; the rest were unreachable once it raised:

```python
with pytest.raises(Exception):
    _check_input_maybe_try_transform(1)
    _check_input_maybe_try_transform(1.0)   # never ran
    _check_input_maybe_try_transform(None)  # never ran
    ...
```

**Five of the six "wrong inputs" were never tested.** Now parametrized, asserting `TypeError` for each — which is why the suite goes from **45 to 51 passing**. Six genuine assertions that were silently absent, surfaced by the linter rather than by reading the test.

### One suppression

`DTZ001` on the fixture's `datetime(...)`. Making it tz-aware would change the column's dtype and therefore what the tests assert, so it stays naive with a targeted `noqa` and a stated reason rather than a blanket ignore.

## The version guards itself

Pinning in the workflow would otherwise just relocate the drift problem, so ruff asserts its own version:

```toml
[tool.ruff]
required-version = "==0.16.0"
```

Verified both directions — `uvx ruff@0.14.0 check .` fails with `Required version ==0.16.0 does not match the running version 0.14.0`.

That guard also caught a pre-existing inconsistency when first added: `.pre-commit-config.yaml` pinned **v0.5.0** while CI ran **0.5.6**, so hooks and CI had been linting under different versions. Both now at 0.16.0.

## Test plan

- [x] `ruff 0.16.0` check and `format --check` clean
- [x] `uv run pytest` — **51 passed**
- [x] README renders byte-identical through `uv run quarto`
- [x] All four pins in step: `required-version`, dev group, `.pre-commit-config.yaml`, `lint.yaml`
- [x] Confirmed the lint job contains no `uv sync`


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_