### PR TITLE
PR 0 — plumbing for the narwhals rewrite: strict xfail, markers, burndown (#37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,15 @@ uv build             # sdist + wheel
   overwritten.
 - Update `changelog.md` (Keep a Changelog format) for user-facing changes.
 
+## Rewrite in progress (#37)
+
+Tests for not-yet-migrated behaviour are marked
+`@pytest.mark.rewrite` + `@pytest.mark.xfail(strict=True, reason="#37: ...")`.
+`xfail_strict = true`, so an unexpected pass fails the build — remove both
+markers in the PR that implements the behaviour, never separately.
+`make burndown` counts what's left. Full plan and the `make_stats_tbl`
+return-type decision: issue #37.
+
 ## Issue work — always open a PR
 
 When asked to work an issue (or issues) from this repo's GitHub tracker:

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ test:
 
 test2: reqs test
 
+## Count remaining rewrite xfails
+.PHONY: burndown
+burndown:
+	@uv run pytest -m rewrite --collect-only -q | tail -n 1
+
 
 ## Make README 
 .PHONY: README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+# A test that unexpectedly passes fails the build, so a rewrite marker cannot
+# be left behind after the behaviour it describes has been implemented.
+xfail_strict = true
+markers = [
+  "rewrite: behaviour targeted by the narwhals rewrite (#37), xfail until implemented",
+  "integration: slower end-to-end test, deselected in CI",
+]
 
 [project.urls]
 Homepage = "https://github.com/matthiaskaeding/showstats"


### PR DESCRIPTION
PR 0 of the #37 chain. **No tests, no behaviour change** — this only puts the ratchet in place so later PRs can land the expected-failing battery without `main` going red.

## What's here

**`xfail_strict = true`** — the mechanism that makes "not implemented yet" safe to express in the suite. A test that unexpectedly passes *fails* the build, so a `rewrite` marker cannot survive the PR that implements its behaviour.

I verified this rather than assuming the setting does what it says. A probe test marked `xfail(strict=True)` whose body actually passes:

```
[XPASS(strict)] #37: probe
FAILED tests/test_ratchet_probe.py::test_probe_that_actually_passes
```

Probe removed afterwards; it existed only to prove the ratchet bites.

**Two markers registered.** `rewrite` is new. `integration` is not — `pytest.yaml` has been filtering on `-m "not integration"` all along without the marker ever being declared, so it was an unregistered marker in practice. Now both are declared, and `-W error::pytest.PytestUnknownMarkWarning` passes clean.

**`make burndown`** counts what's left:

```
$ make burndown
no tests collected (51 deselected)
```

**Starting burndown count: 0** — nothing marked yet, as expected before PR 1.

**`CLAUDE.md`** gains a "Rewrite in progress (#37)" section recording the marker convention and pointing at this issue for the plan, so later work doesn't reinvent it.

## Safe to enable

There were **no `xfail`, `xpass` or `skip` markers anywhere in `tests/`** beforehand — the last three skips went in #67. The suite is 51 passed, 0 skipped, so strict mode changes nothing today.

## Acceptance

- [x] `uv run pytest` — 51 passed
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] No unknown-marker warnings
- [x] `make burndown` runs and reports 0

## Blocking question before PR 1

The plan requires the `make_stats_tbl` return type to be decided **with maintainer sign-off before the battery lands**, because it determines whether the existing assertions need migrating first. I've not picked one. Raised separately — see the comment on #37.

## Pre-existing warts noticed, deliberately not fixed here

Per the plan, reporting rather than folding drive-by fixes into rewrite slices:

1. **`test_table.py::test_pandas` has its variables inverted** — `_table_pandas` is built from the *polars* frame and `_table_polars` from the pandas one. It also takes the `sample_df` fixture without using it.
2. **`noxfile.py`'s lint session does an unpinned `session.install("ruff")`** — that will break against `required-version = "==0.16.0"` the moment ruff ships 0.17.
3. **The `timing` Makefile target does `cd notebooks`**, but the notebook is at `docs/timing.ipynb`.

Happy to open issues for these.


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_