### PR TITLE
PR 0.5 — make the stats-table assertions backend-agnostic (#37)

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,31 @@
+"""Assertion helpers shared across the test suite.
+
+`make_stats_tbl` returns the input's native type (#37) — pandas in, pandas
+out — so tests must not reach for polars methods on its result. Routing
+assertions through narwhals keeps one set of expectations that hold both on
+today's polars-returning implementation and on the native-returning one.
+"""
+
+from __future__ import annotations
+
+import narwhals as nw
+
+
+def stats_frame(result) -> nw.DataFrame:
+    """Wrap a `make_stats_tbl` result so assertions do not assume a backend."""
+    return nw.from_native(result, eager_only=True)
+
+
+def cell(result, row: int, column: str):
+    """Read one cell from a `make_stats_tbl` result, backend-agnostically."""
+    return stats_frame(result)[column][row]
+
+
+def row_for(result, variable: str) -> nw.DataFrame:
+    """The stats row describing `variable`, backend-agnostically.
+
+    The first column holds the variable names but is titled with the row count
+    (``Col (N=10)``), so it is addressed by position rather than by name.
+    """
+    frame = stats_frame(result)
+    return frame.filter(nw.col(frame.columns[0]) == variable)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,6 +7,7 @@ import polars as pl
 
 from showstats import show_stats
 from showstats.showstats import make_stats_tbl
+from tests.helpers import cell, row_for, stats_frame
 
 
 def test_polars_backend_basic():
@@ -29,7 +30,7 @@ def test_polars_backend_basic():
     # Test make_stats_tbl
     result = make_stats_tbl(df, "num")
     assert result is not None
-    assert result.shape[0] == 2  # int_col and float_col
+    assert stats_frame(result).shape[0] == 2  # int_col and float_col
 
 
 def test_pandas_backend_basic():
@@ -52,7 +53,7 @@ def test_pandas_backend_basic():
     # Test make_stats_tbl
     result = make_stats_tbl(df, "num")
     assert result is not None
-    assert result.shape[0] == 2  # int_col and float_col
+    assert stats_frame(result).shape[0] == 2  # int_col and float_col
 
 
 def test_polars_vs_pandas_numeric_stats():
@@ -70,7 +71,7 @@ def test_polars_vs_pandas_numeric_stats():
     result_pandas = make_stats_tbl(df_pandas, "num")
 
     # Both should have same shape
-    assert result_polars.shape == result_pandas.shape
+    assert stats_frame(result_polars).shape == stats_frame(result_pandas).shape
 
     # Variable names should be the same
     assert (
@@ -99,7 +100,7 @@ def test_polars_vs_pandas_categorical_stats():
     result_pandas = make_stats_tbl(df_pandas, "cat")
 
     # Both should have same shape
-    assert result_polars.shape == result_pandas.shape
+    assert stats_frame(result_polars).shape == stats_frame(result_pandas).shape
 
     # Variable names should be the same
     assert (
@@ -122,10 +123,10 @@ def test_polars_backend_with_nulls():
     result = make_stats_tbl(df, "num")
 
     # col_with_nulls should have 20% NA (2 out of 10)
-    assert result.filter(pl.col("Col (N=10)") == "col_with_nulls")["NA%"][0] == 20
+    assert row_for(result, "col_with_nulls")["NA%"][0] == 20
 
     # col_no_nulls should have 0% NA
-    assert result.filter(pl.col("Col (N=10)") == "col_no_nulls")["NA%"][0] == 0
+    assert row_for(result, "col_no_nulls")["NA%"][0] == 0
 
 
 def test_pandas_backend_with_nulls():
@@ -140,12 +141,10 @@ def test_pandas_backend_with_nulls():
     result = make_stats_tbl(df, "num")
 
     # col_with_nulls should have 20% NA (2 out of 10)
-    col_with_nulls_row = result.filter(pl.col("Col (N=10)") == "col_with_nulls")
-    assert col_with_nulls_row["NA%"][0] == 20
+    assert row_for(result, "col_with_nulls")["NA%"][0] == 20
 
     # col_no_nulls should have 0% NA
-    col_no_nulls_row = result.filter(pl.col("Col (N=10)") == "col_no_nulls")
-    assert col_no_nulls_row["NA%"][0] == 0
+    assert row_for(result, "col_no_nulls")["NA%"][0] == 0
 
 
 def test_polars_backend_datetime():
@@ -164,14 +163,14 @@ def test_polars_backend_datetime():
     result = make_stats_tbl(df, "time")
 
     # Should have 2 rows (date_col and datetime_col)
-    assert result.shape[0] == 2
+    assert stats_frame(result).shape[0] == 2
 
     # Should have columns: Col (N=10), NA%, Min, Max, Median
-    assert "Col (N=10)" in result.columns
-    assert "NA%" in result.columns
-    assert "Min" in result.columns
-    assert "Max" in result.columns
-    assert "Median" in result.columns
+    assert "Col (N=10)" in stats_frame(result).columns
+    assert "NA%" in stats_frame(result).columns
+    assert "Min" in stats_frame(result).columns
+    assert "Max" in stats_frame(result).columns
+    assert "Median" in stats_frame(result).columns
 
 
 def test_pandas_backend_datetime():
@@ -183,13 +182,13 @@ def test_pandas_backend_datetime():
     result = make_stats_tbl(df, "time")
 
     assert result is not None
-    assert "Median" in result.columns
+    assert "Median" in stats_frame(result).columns
     # The median of ten consecutive days is midday on the fifth. Getting this
     # right is what the Int64 round-trip in _median_expr is for: a wrong time
     # unit would silently land in 1970.
-    assert result.item(0, "Median").startswith("2020-01-05 12:00:00")
-    assert result.item(0, "Min").startswith("2020-01-01")
-    assert result.item(0, "Max").startswith("2020-01-10")
+    assert cell(result, 0, "Median").startswith("2020-01-05 12:00:00")
+    assert cell(result, 0, "Min").startswith("2020-01-01")
+    assert cell(result, 0, "Max").startswith("2020-01-10")
 
 
 def test_polars_backend_boolean():
@@ -215,7 +214,7 @@ def test_polars_backend_boolean():
     result = make_stats_tbl(df, "num")
 
     # Should have 2 rows (bool_col and int_col)
-    assert result.shape[0] == 2
+    assert stats_frame(result).shape[0] == 2
 
     # bool_col should be included
     assert "bool_col" in result["Col (N=10)"].to_list()
@@ -244,11 +243,10 @@ def test_pandas_backend_boolean():
     result = make_stats_tbl(df, "num")
 
     assert result is not None
-    assert result.shape[0] >= 1
+    assert stats_frame(result).shape[0] >= 1
     # Five True out of ten, so the median of the boolean column is 0.5 —
     # the same value polars reports for median() on a boolean.
-    bool_row = result.filter(pl.col(result.columns[0]) == "bool_col")
-    assert bool_row.item(0, "Median") == "0.5"
+    assert row_for(result, "bool_col")["Median"][0] == "0.5"
 
 
 def test_polars_backend_all_types():
@@ -341,9 +339,9 @@ def test_polars_backend_categorical_top_values():
     result = make_stats_tbl(df, "cat")
 
     # Should have Top 1, Top 2, Top 3 columns
-    assert "Top 1" in result.columns
-    assert "Top 2" in result.columns
-    assert "Top 3" in result.columns
+    assert "Top 1" in stats_frame(result).columns
+    assert "Top 2" in stats_frame(result).columns
+    assert "Top 3" in stats_frame(result).columns
 
     # Top 1 should be A with 50%
     assert "A (50%)" in result["Top 1"][0]
@@ -360,9 +358,9 @@ def test_pandas_backend_categorical_top_values():
     result = make_stats_tbl(df, "cat")
 
     # Should have Top 1, Top 2, Top 3 columns
-    assert "Top 1" in result.columns
-    assert "Top 2" in result.columns
-    assert "Top 3" in result.columns
+    assert "Top 1" in stats_frame(result).columns
+    assert "Top 2" in stats_frame(result).columns
+    assert "Top 3" in stats_frame(result).columns
 
     # Top 1 should be A with 50%
     assert "A (50%)" in result["Top 1"][0]

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -1,17 +1,17 @@
-import polars as pl
-
 from showstats.showstats import make_stats_tbl
+from tests.helpers import stats_frame
 
 
 def test_make_stats_tbl(sample_df):
-    res_num = make_stats_tbl(sample_df, "num")
-    assert isinstance(res_num, pl.DataFrame)
-    res_cat = make_stats_tbl(sample_df, "cat")
-    assert isinstance(res_cat, pl.DataFrame)
+    # make_stats_tbl returns the input's native type (#37), so assert on the
+    # shape of the result rather than on a particular dataframe class.
+    res_num = stats_frame(make_stats_tbl(sample_df, "num"))
+    assert res_num.shape[0] > 0
+    res_cat = stats_frame(make_stats_tbl(sample_df, "cat"))
+    assert res_cat.shape[0] > 0
 
 
 def test_make_stats_tbl_quantiles(sample_df):
-    res_num = make_stats_tbl(sample_df, "num", quantiles=[0.25, 0.75])
-    assert isinstance(res_num, pl.DataFrame)
+    res_num = stats_frame(make_stats_tbl(sample_df, "num", quantiles=[0.25, 0.75]))
     assert "Q25" in res_num.columns
     assert "Q75" in res_num.columns


### PR DESCRIPTION
PR 0.5 of the #37 chain. **Tests only — no behaviour change.**

## Why this exists

You signed off on `make_stats_tbl` returning the input's native type ([decision on #37](https://github.com/matthiaskaeding/showstats/issues/37#issuecomment-5096809806)). The plan requires that, when the answer isn't "keep returning polars", the existing assertions are migrated **before** the xfail battery — so the rewrite has a regression net that stays still rather than shifting underneath it.

## The problem

Ten tests feed **pandas** frames into `make_stats_tbl` and then assert with **polars-only** calls:

```python
result = make_stats_tbl(pd.DataFrame(...), "num")

result.filter(pl.col("Col (N=10)") == "col_with_nulls")["NA%"][0]
result.item(0, "Median")
assert isinstance(res_num, pl.DataFrame)
```

These pass today *only* because the return is always polars whatever goes in. They break the moment the return type follows the input — which is exactly what #37 will do.

## The fix

`tests/helpers.py` routes them through narwhals:

| helper | |
|---|---|
| `stats_frame(result)` | wrap a result so assertions don't assume a backend |
| `cell(result, row, column)` | read one cell |
| `row_for(result, variable)` | select the row describing a variable |

`row_for` also removes a latent brittleness: the tests hardcoded the header string `"Col (N=10)"` to find the name column, but that column's title carries the **row count** — so it's really addressed by position. A fixture with a different row count would have silently failed to match.

## Verified on both sides — the point of this PR

An assertion net is only stable if it holds before *and* after. So I checked both rather than just the current state:

| | |
|---|---|
| today (always returns polars) | **51 passed** |
| `make_stats_tbl` temporarily patched to return pandas for pandas input | **51 passed** |

The simulation was reverted; `src/` is untouched in this commit (`git diff --stat src/` is empty).

## Note on placement

Helpers live in `tests/helpers.py`, not `conftest.py`. `tests` is already a package, so importing from `conftest` isn't needed, and this leaves the fixtures `docs/timing.ipynb` loads by path alone — the plan warns against disturbing those.

## Acceptance

- [x] `uv run pytest` — 51 passed
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] No `src/` changes
- [x] Suite verified against a simulated native return

## Sequencing

Independent of #72 (PR 0) — that touches `pyproject.toml`/`Makefile`/`CLAUDE.md`, this touches `tests/`. Either order merges cleanly. **PR 1 (the battery) needs both.**


---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_