### PR TITLE
PR 1 — the #37 xfail battery, plus golden snapshots of the current rendering

### DIFF
--- a/tests/_golden.py
+++ b/tests/_golden.py
@@ -1,0 +1,100 @@
+"""Golden renderings of the printed table, captured before #37 touches it.
+
+Generated from the current renderer, not transcribed by hand. The exact
+spacing is a real contract: it is what appears verbatim in README.md, and it
+comes from the ``pl.Config`` block in ``_Table.show_one_table``
+(``float_precision=2``, ``set_tbl_width_chars=80``,
+``tbl_cell_alignment="LEFT"``). The rewrite replaces that renderer with a
+hand-written formatter, so any drift has to show up here rather than in a
+README diff.
+
+Warts are pinned along with everything else — see the notes in
+``tests/test_golden_output.py``. If a slice deliberately changes one of
+these, the golden changes in its own commit with the reason, never quietly
+alongside the implementation.
+"""
+
+NUM = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    Median  Min    Max  \n"
+    " float_col  0    3.5  1.58  3.5     1.5    5.5  \n"
+    " int_col    20   2.5  1.29  2.5     1      4    \n"
+    " bool_col   0    0.6  0.55  1.0     false  true \n"
+)
+
+CAT = (
+    "-Categorical columns------------------------------------------------------------\n"
+    " Col (N=10)  NA%  Uniques  Top 1    Top 2    Top 3   \n"
+    " cat_col     0    3        A (50%)  B (30%)  C (20%) \n"
+    " other_col   10   3        x (50%)  y (40%)          \n"
+)
+
+TIME = (
+    "-Date and datetime columns------------------------------------------------------\n"
+    " Col (N=5)     NA%  Median      Min                  Max                 \n"
+    " date_col      0    2020-01-03  2020-01-01           2020-01-05          \n"
+    " datetime_col  0    2020-01-03  2020-01-01 12:30:15  2020-01-05 12:30:15 \n"
+    "                    12:30:15                                             \n"
+)
+
+ALL = (
+    "-Date and datetime columns------------------------------------------------------\n"
+    " Col (N=5)  NA%  Median      Min         Max        \n"
+    " date_col   0    2020-01-03  2020-01-01  2020-01-05 \n"
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    Median  Min  Max \n"
+    " float_col  0    3.5  1.58  3.5     1.5  5.5 \n"
+    " int_col    0    3.0  1.58  3.0     1    5   \n"
+    "-Categorical columns------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Uniques  Top 1    Top 2    Top 3   \n"
+    " str_col    0    3        a (40%)  b (40%)  c (20%) \n"
+)
+
+LONG_NAMES = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=3)                       NA%  Avg  SD   Median  Min  Max \n"
+    " short                           0    2.0  1.0  2.0     1.0  3.0 \n"
+    " a_very_long_column_name_that_…  0    2.0  1.0  2.0     1    3   \n"
+)
+
+SCIENTIFIC = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=4)  NA%  Avg     SD      Median  Min  Max    \n"
+    " big_col    0    2.47E9  4.93E9  6173.0  0.0  9.87E9 \n"
+)
+
+NULL_COLUMN = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    Median  Min  Max \n"
+    " int_col    0    3.0  1.58  3.0     1    5   \n"
+    " null_col   100                              \n"
+)
+
+BIG_N = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=1.50E+5)  NA%  Avg      SD        Median   Min  Max    \n"
+    " int_col          0    74999.5  43301.41  74999.5  0    149999 \n"
+)
+
+QUANTILES_FOLDED = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    …  Q25   Q50  Q75   Q100 \n"
+    " float_col  0    3.5  1.58  …  2.5   3.5  4.5   5.5  \n"
+    " int_col    20   2.5  1.29  …  1.75  2.5  3.25  4    \n"
+    " bool_col   0    0.6  0.55  …  0.0   1.0  1.0   true \n"
+)
+
+QUANTILES_UNFOLDED = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    Median  Q25   Min    Max  \n"
+    " float_col  0    3.5  1.58  3.5     2.5   1.5    5.5  \n"
+    " int_col    20   2.5  1.29  2.5     1.75  1      4    \n"
+    " bool_col   0    0.6  0.55  1.0     0.0   false  true \n"
+)
+
+TOP_COLS = (
+    "-Numerical columns--------------------------------------------------------------\n"
+    " Col (N=5)  NA%  Avg  SD    Median  Min  Max \n"
+    " int_col    0    3.0  1.58  3.0     1    5   \n"
+    " float_col  0    3.5  1.58  3.5     1.5  5.5 \n"
+)

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -1,0 +1,137 @@
+"""Pin the rendered output before the rewrite touches rendering.
+
+`show_one_table` prints through `pl.Config`. #37 replaces that with a
+hand-written formatter, and there is no narwhals renderer to fall back on —
+so the printed layout is entirely re-implemented by the last slice. These
+snapshots are what makes that re-implementation checkable: without them the
+first place a spacing change would surface is a README diff, since
+README.md embeds this output verbatim.
+
+None of these are marked `rewrite`. They describe behaviour that must
+survive the rewrite unchanged, so they are expected to pass throughout.
+
+Three current warts are pinned here deliberately rather than fixed:
+
+1. `QUANTILES_FOLDED` is missing its Q0 column — polars elides columns that
+   do not fit `set_tbl_width_chars=80`, replacing them with `…`. So asking
+   for enough quantiles silently drops the minimum.
+2. `TIME` wraps the datetime median onto a second, unaligned line for the
+   same reason.
+3. Numbers render differently depending on the input backend — see
+   `test_rewrite.py::test_pandas_renders_like_polars`, which is the xfail
+   that owns that one.
+
+Changing any of these is a deliberate act: update the golden in its own
+commit, with the reason, plus a changelog entry. Never quietly, alongside
+an implementation change.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import polars as pl
+import pytest
+
+from showstats.showstats import show_stats
+from tests import _golden
+
+MIXED = pl.DataFrame(
+    {
+        "int_col": [1, 2, 3, 4, None],
+        "float_col": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "bool_col": [True, False, True, False, True],
+    }
+)
+
+CAT = pl.DataFrame(
+    {
+        "cat_col": ["A"] * 5 + ["B"] * 3 + ["C"] * 2,
+        "other_col": ["x", "y", None, "x", "x", "y", "y", "x", "x", "y"],
+    }
+)
+
+TIME = pl.DataFrame(
+    {
+        "date_col": [date(2020, 1, d) for d in range(1, 6)],
+        # naive on purpose: a tz-aware value would change the column's dtype
+        # and so the rendered string
+        "datetime_col": [datetime(2020, 1, d, 12, 30, 15) for d in range(1, 6)],  # noqa: DTZ001
+    }
+)
+
+ALL = pl.DataFrame(
+    {
+        "int_col": [1, 2, 3, 4, 5],
+        "float_col": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "str_col": ["a", "b", "c", "a", "b"],
+        "date_col": [date(2020, 1, d) for d in range(1, 6)],
+    }
+)
+
+LONG = pl.DataFrame(
+    {
+        "a_very_long_column_name_that_exceeds_the_limit": [1, 2, 3],
+        "short": [1.0, 2.0, 3.0],
+    }
+)
+
+BIG = pl.DataFrame({"big_col": [1e-7, 1.0, 12345.0, 9.87e9]})
+
+NULLS = pl.DataFrame({"null_col": [None] * 5, "int_col": [1, 2, 3, 4, 5]})
+
+MANY_ROWS = pl.DataFrame({"int_col": range(150_000)})
+
+
+def render(capsys, df, **kwargs) -> str:
+    show_stats(df, **kwargs)
+    return capsys.readouterr().out
+
+
+CASES = [
+    ("num table", _golden.NUM, MIXED, {"table_type": "num"}),
+    ("cat table", _golden.CAT, CAT, {"table_type": "cat"}),
+    ("time table", _golden.TIME, TIME, {"table_type": "time"}),
+    ("all three sections", _golden.ALL, ALL, {"table_type": "all"}),
+    ("name truncation", _golden.LONG_NAMES, LONG, {"table_type": "num"}),
+    ("scientific notation", _golden.SCIENTIFIC, BIG, {"table_type": "num"}),
+    ("all-null column", _golden.NULL_COLUMN, NULLS, {"table_type": "num"}),
+    ("scientific row count", _golden.BIG_N, MANY_ROWS, {"table_type": "num"}),
+    (
+        "folded quantiles",
+        _golden.QUANTILES_FOLDED,
+        MIXED,
+        {"table_type": "num", "quantiles": [0.25, 0.5, 0.75]},
+    ),
+    (
+        "unfolded quantiles",
+        _golden.QUANTILES_UNFOLDED,
+        MIXED,
+        {"table_type": "num", "quantiles": [0.25], "fold_quantiles": False},
+    ),
+    (
+        "top_cols ordering",
+        _golden.TOP_COLS,
+        ALL,
+        {"table_type": "num", "top_cols": "int_col"},
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("expected", "df", "kwargs"),
+    [pytest.param(*case[1:], id=case[0]) for case in CASES],
+)
+def test_rendered_output_matches_golden(capsys, expected, df, kwargs):
+    assert render(capsys, df, **kwargs) == expected
+
+
+def test_every_golden_line_fits_the_configured_width(capsys):
+    """80 chars is the configured table width, and README.md relies on it.
+
+    Checked as an invariant as well as inside the snapshots, so a golden
+    that is updated carelessly still cannot smuggle in a wider table.
+    """
+    for name, _expected, df, kwargs in CASES:
+        for line in render(capsys, df, **kwargs).splitlines():
+            assert len(line) <= 80, f"{name}: {len(line)} chars: {line!r}"

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -1,0 +1,313 @@
+"""The behaviour #37 is aiming at, declared up front and expected to fail.
+
+Every test here is `@pytest.mark.rewrite` + a strict xfail: it describes
+something the narwhals migration is supposed to make true and that is not
+true yet. `xfail_strict = true` turns each one into a ratchet — the moment a
+slice makes one pass, the build fails until its markers are removed. So the
+markers cannot rot, and `make burndown` is an honest count of what is left.
+
+Tests are grouped by the implementation slice that should retire them, in
+the order the slices land. Nothing here is marked `integration`: CI
+deselects that marker, and hiding a rewrite test from CI would defeat the
+whole arrangement.
+
+Behaviour that already works is *not* here — it lives in the ordinary test
+files, and in `test_golden_output.py`, as the regression net.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import narwhals as nw
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+import pytest
+
+from showstats._utils import convert_df_scientific
+from showstats.showstats import make_stats_tbl, show_stats
+from tests import _golden
+
+pytestmark = pytest.mark.rewrite
+
+# The same data in three backends. Going through polars' own converters
+# keeps the dtypes corresponding — a hand-built pandas frame would differ in
+# ways that have nothing to do with the rewrite (int64 vs float64 for a
+# column with nulls, say), and the tests would then be measuring the
+# conversion rather than showstats.
+MIXED_PL = pl.DataFrame(
+    {
+        "int_col": [1, 2, 3, 4, 5],
+        "float_col": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "str_col": ["a", "b", "c", "a", "b"],
+    }
+)
+MIXED_PD = MIXED_PL.to_pandas()
+MIXED_PA = MIXED_PL.to_arrow()
+
+
+def render(capsys, df, **kwargs) -> str:
+    show_stats(df, **kwargs)
+    return capsys.readouterr().out
+
+
+def run_without_polars(body: str) -> subprocess.CompletedProcess:
+    """Run `body` in a fresh interpreter where importing polars raises.
+
+    A subprocess rather than monkeypatching `sys.modules`: `showstats` and
+    `polars` are both already imported by the time a test runs, so an
+    in-process block would only prove that the *cached* modules still work.
+    The finder has to be in place before showstats is imported at all.
+    """
+    script = textwrap.dedent("""
+        import sys
+
+        class NoPolars:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "polars" or fullname.startswith("polars."):
+                    raise ImportError("polars is not installed")
+                return None
+
+        sys.meta_path.insert(0, NoPolars())
+        assert "polars" not in sys.modules
+    """) + textwrap.dedent(body)
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# --------------------------------------------------------------------------
+# Slice 1 — the backend fork in _Table.__init__
+#
+# `__init__` branches on `isinstance(native_stats, pl.DataFrame)` and falls
+# back to `.iloc[0]` for "pandas", with a second, separately hand-rolled
+# value_counts path for categoricals. pyarrow reaches that fallback and dies
+# on it, so a pyarrow frame that `_check_input_maybe_try_transform` happily
+# accepts (see test_utils.py::test_input_check_pyarrow) cannot in fact be
+# summarised. Collapsing the fork to one narwhals path fixes all three.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#37: _Table.__init__ falls back to .iloc[0], which pyarrow has no",
+)
+def test_pyarrow_numeric_table():
+    result = make_stats_tbl(MIXED_PA, "num")
+    assert nw.from_native(result, eager_only=True).shape[0] == 2
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#37: the categorical value_counts path in _Table.__init__ is pandas-only",
+)
+def test_pyarrow_categorical_table():
+    result = make_stats_tbl(MIXED_PA, "cat")
+    frame = nw.from_native(result, eager_only=True)
+    assert "Top 1" in frame.columns
+    assert frame["Top 1"][0] == "a (40%)"
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: show_stats cannot render a pyarrow table at all"
+)
+def test_pyarrow_show_stats(capsys):
+    show_stats(MIXED_PA, "all")
+    assert "int_col" in capsys.readouterr().out
+
+
+# --------------------------------------------------------------------------
+# Slice 2 — _utils.convert_df_scientific
+#
+# A pure polars expression pipeline today. It is internal, so the target is
+# only that it stops caring which backend it is handed: same frame kind in,
+# same frame kind out. The existing polars assertions in
+# test_scientific_conversion.py stay as they are and go on passing.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: convert_df_scientific builds polars expressions"
+)
+def test_convert_df_scientific_accepts_pandas():
+    df = pd.DataFrame({"values": [0.1, 10.0, 1000.0, 10000.0, 100000.0]})
+    result = convert_df_scientific(df, ["values"])
+    assert isinstance(result, pd.DataFrame)
+    assert result["values"].tolist() == ["0.1", "10.0", "1000.0", "10000.0", "1.0E5"]
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: convert_df_scientific builds polars expressions"
+)
+def test_convert_df_scientific_accepts_narwhals():
+    df = nw.from_native(pl.DataFrame({"values": [0.1, 1e5]}), eager_only=True)
+    result = convert_df_scientific(df, ["values"])
+    assert isinstance(result, nw.DataFrame)
+    assert result["values"].to_list() == ["0.1", "1.0E5"]
+
+
+# --------------------------------------------------------------------------
+# Slice 3 — _Table.make_dt
+#
+# Builds a pl.LazyFrame per var-type regardless of what came in, which is
+# where the polars dependency re-enters after the stats have been computed
+# through narwhals.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(strict=True, reason="#37: make_dt always builds a pl.LazyFrame")
+@pytest.mark.parametrize(
+    ("df", "native_type"),
+    [
+        pytest.param(MIXED_PD, pd.DataFrame, id="pandas"),
+        pytest.param(MIXED_PA, pa.Table, id="pyarrow"),
+    ],
+)
+def test_make_dt_follows_the_input_backend(df, native_type):
+    from showstats._table import _Table
+
+    table = _Table(df, "num")
+    result = table.make_dt("num_int")
+    assert isinstance(nw.to_native(nw.from_native(result)), native_type)
+
+
+# --------------------------------------------------------------------------
+# Slice 4 — _Table.form_stat_df and the return type
+#
+# make_stats_tbl returns a pl.DataFrame whatever it is given. The agreed
+# outcome (see the sign-off on #37) is that the return follows the input.
+# The polars case already holds today and so is asserted in
+# test_make_tbl.py, unmarked, rather than here.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: form_stat_df collects to polars whatever came in"
+)
+@pytest.mark.parametrize(
+    ("df", "native_type"),
+    [
+        pytest.param(MIXED_PD, pd.DataFrame, id="pandas"),
+        pytest.param(MIXED_PA, pa.Table, id="pyarrow"),
+    ],
+)
+def test_make_stats_tbl_returns_the_input_type(df, native_type):
+    assert isinstance(make_stats_tbl(df, "num"), native_type)
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: form_stat_df orders top_cols by casting to pl.Enum"
+)
+def test_top_cols_ordering_survives_the_backend_change():
+    """top_cols currently works by casting to pl.Enum and sorting.
+
+    narwhals has no equivalent, so the ordering needs a different
+    implementation — and it has to keep working, natively, for a
+    non-polars input.
+    """
+    result = make_stats_tbl(MIXED_PD, "num", top_cols="float_col")
+    assert isinstance(result, pd.DataFrame)
+    assert result[result.columns[0]].tolist() == ["float_col", "int_col"]
+
+
+# --------------------------------------------------------------------------
+# Slice 5 — _Table.show_one_table
+#
+# Printing goes through pl.Config, so there is no polars-free path to the
+# output at all. Two things have to become true: the rendering stops
+# depending on the input backend, and polars stops being importable-or-bust.
+#
+# Which rendering wins is not open: the polars one, because README.md is
+# generated from it and is pinned in test_golden_output.py. So these
+# compare against the polars rendering of the same data, not merely against
+# each other.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#37: pandas input renders int min/max as 1.0 and Uniques as 3.00",
+)
+@pytest.mark.parametrize(
+    "df",
+    [pytest.param(MIXED_PD, id="pandas"), pytest.param(MIXED_PA, id="pyarrow")],
+)
+def test_rendering_does_not_depend_on_the_input_backend(capsys, df):
+    assert render(capsys, df, table_type="all") == render(
+        capsys, MIXED_PL, table_type="all"
+    )
+
+
+@pytest.mark.xfail(strict=True, reason="#37: showstats._table imports polars at import")
+def test_showstats_imports_without_polars():
+    result = run_without_polars("""
+        import showstats
+        assert "polars" not in sys.modules
+        print("ok")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+@pytest.mark.xfail(strict=True, reason="#37: rendering goes through pl.Config")
+def test_show_stats_renders_without_polars():
+    result = run_without_polars(f"""
+        import pandas as pd
+        from showstats import show_stats
+
+        df = pd.DataFrame({MIXED_PL.to_dict(as_series=False)!r})
+        show_stats(df, "num")
+        assert "polars" not in sys.modules
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "int_col" in result.stdout
+
+
+@pytest.mark.xfail(
+    strict=True, reason="#37: form_stat_df needs polars to build a frame"
+)
+def test_make_stats_tbl_works_without_polars():
+    result = run_without_polars(f"""
+        import pandas as pd
+        from showstats.showstats import make_stats_tbl
+
+        df = pd.DataFrame({MIXED_PL.to_dict(as_series=False)!r})
+        out = make_stats_tbl(df, "num")
+        assert isinstance(out, pd.DataFrame), type(out)
+        assert "polars" not in sys.modules
+        print("ok")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+# --------------------------------------------------------------------------
+# The finish line — what "#37 is done" means, in one test.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(strict=True, reason="#37: polars is still a hard runtime dependency")
+def test_the_readme_table_renders_without_polars():
+    """The whole point, end to end: the documented output, no polars.
+
+    Compared against the golden captured from the current renderer, so
+    "works without polars" cannot be achieved by rendering something else.
+    """
+    data = {
+        "cat_col": ["A"] * 5 + ["B"] * 3 + ["C"] * 2,
+        "other_col": ["x", "y", None, "x", "x", "y", "y", "x", "x", "y"],
+    }
+    result = run_without_polars(f"""
+        import pandas as pd
+        from showstats import show_stats
+
+        show_stats(pd.DataFrame({data!r}), "cat")
+    """)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == _golden.CAT


### PR DESCRIPTION
PR 1 of the #37 chain, on top of #72 (plumbing) and #73 (backend-agnostic assertions). **Tests only — `git diff --stat src/` is empty.**

**Starting burndown: 16.**

```
$ uv run pytest
63 passed, 16 xfailed

$ make burndown
16/79 tests collected (63 deselected)
```

Zero `failed`, zero `xpassed`, as the plan requires.

## Two halves, and the second needs the first

### `tests/test_golden_output.py` — what must not change

The plan says to snapshot the rendered output *before* rendering is touched, and that turned out to be the load-bearing part of this PR. Slice 5 replaces `pl.Config` with a hand-written formatter; there is no narwhals renderer to lean on, so the printed layout gets re-implemented from nothing. Eleven cases are pinned: each table type, name truncation, scientific notation, an all-null column, folded and unfolded quantiles, `top_cols` ordering, and a >100k row count.

Two details worth stating:

- **The goldens are generated, not transcribed.** `tests/_golden.py` was written by a script that ran the current renderer. Hand-copying 80-column output with meaningful trailing spaces would have been a source of fake failures.
- **They are not polars-version-sensitive.** `noxfile.py` tests polars 0.20.21 as well as current, and a golden that only held on one of them would be a trap for the final PR. Checked: `uv run --isolated --with "polars==0.20.21" … pytest tests/test_golden_output.py` → 12 passed.

These are **not** marked `rewrite`. They describe behaviour that must survive.

### `tests/test_rewrite.py` — what must become true

Sixteen strict xfails, grouped by the slice that should retire each, in landing order. I checked every one fails *for its stated reason* (`--runxfail` locally) rather than merely failing.

| Slice | Tests | Fails today with |
|---|---|---|
| 1 — the backend fork in `_Table.__init__` | 3 | `AttributeError: 'pyarrow.lib.Table' object has no attribute 'iloc'` |
| 2 — `convert_df_scientific` | 2 | `'DataFrame' object has no attribute 'with_columns'` / `InvalidIntoExprError` |
| 3 — `make_dt` | 2 | returns a `pl.LazyFrame` whatever went in |
| 4 — `form_stat_df`, return type, `top_cols` | 3 | returns `pl.DataFrame` whatever went in |
| 5 — `show_one_table` | 5 | `ImportError: polars is not installed` |
| the finish line | 1 | ditto |

## One finding worth flagging: pyarrow does not work at all today

`_check_input_maybe_try_transform` accepts pyarrow, and `test_utils.py::test_input_check_pyarrow` asserts it does. But `_Table.__init__`'s backend fork is `if isinstance(native_stats, pl.DataFrame): … else: native_stats.iloc[0]` — the `else` branch is pandas, not "everything else". So every pyarrow frame reaches `.iloc` and dies:

```python
>>> make_stats_tbl(pa.table({"a": [1, 2, 3]}), "num")
AttributeError: 'pyarrow.lib.Table' object has no attribute 'iloc'
```

That is a real user-facing bug, not just an internal wart, and collapsing the fork in slice 1 is what fixes it. I have left it as an xfail here rather than fixing it inline, per the plan's one-slice-per-PR rule.

## Three warts pinned deliberately

The goldens capture current behaviour including its blemishes, so they are documented in the module docstring rather than silently baked in:

1. **`quantiles=[0.25, 0.5, 0.75]` silently loses the Q0 column.** polars elides columns that do not fit `set_tbl_width_chars=80` and prints `…` in their place, so asking for enough quantiles drops the minimum.
2. **The `time` table wraps a datetime median onto a second, unaligned line**, for the same reason.
3. **Numbers render differently depending on the input backend** — pandas input prints int Min/Max as `1.0`/`5.0` and `Uniques` as `3.00` where polars prints `1`/`5`/`3`.

(3) is owned by an xfail; (1) and (2) are not part of #37. If a slice deliberately changes any of them, the golden changes in its own commit with the reason plus a changelog entry — never quietly alongside an implementation change.

## How "renders without polars" is tested

A subprocess with an import blocker on `sys.meta_path`, not `monkeypatch.setitem(sys.modules, …)`. By the time a test runs, `showstats` and `polars` are both already imported, so an in-process block would only prove the cached modules still work — the finder has to be installed before `showstats` is imported at all. Verified the harness itself is sound: pandas and narwhals import fine under it, and showstats fails precisely at `import polars as pl`.

The last test in the file is the one that says #37 is finished: render the categorical table from a pandas frame, in an interpreter with no polars, and get back the golden string byte for byte. Compared against the golden rather than merely "does not crash", so "works without polars" cannot be satisfied by rendering something else.

## Acceptance

- [x] `uv run pytest` → 63 passed, 16 xfailed; **0 failed, 0 xpassed**
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] No unknown-marker warnings; nothing marked `integration`
- [x] Every `reason` names #37
- [x] `git diff --stat src/` empty
- [x] Goldens verified against polars 0.20.21 as well as current
- [ ] `uv run nox` — not run; the plan requires it before the **final** PR, and this one adds no runtime code

Next: slice 1, the backend fork in `_Table.__init__` — which also fixes pyarrow.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_