### PR TITLE
Slice 2 — convert_df_scientific through narwhals (#37)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Minimum `narwhals` raised from 1.0.0 to 1.40.0, which is where
+  `Expr.log` arrived. The old floor was never checked against anything —
+  see #78, the suite in fact needs 2.0.0 for the pandas backend (#37)
+
 ### Fixed
 
 - pyarrow tables raised `AttributeError: 'pyarrow.lib.Table' object has no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,11 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-dependencies = ["narwhals >= 1.0.0", "polars >= 0.20.21"]
+# 1.40.0 is where narwhals grew Expr.log, which _utils needs. The declared
+# floor of 1.0.0 was never checked against anything; see #78 — the suite in
+# fact needs narwhals >= 2.0.0, which in turn needs Python >= 3.9, so the
+# floor cannot be raised that far without dropping the 3.8 promise.
+dependencies = ["narwhals >= 1.40.0", "polars >= 0.20.21"]
 name = "showstats"
 description = "Vertical summary statistics for data frames"
 authors = [{ name = "Matthias Kaeding" }]
@@ -27,7 +31,7 @@ dev = [
   "build>=1.2.1",
   "hatchling>=1.25.0",
   "jupyter>=1.0.0",
-  "narwhals>=1.0.0",
+  "narwhals>=1.40.0",
   "nbclient==0.10.0",
   "nbformat==5.10.4",
   "nox==2024.4.15",

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -1,57 +1,97 @@
+from __future__ import annotations
+
 from typing import Iterable
 
-import polars as pl
+import narwhals as nw
+
+NAN = float("nan")
 
 
-def make_scientific(varname, thr):
-    var = pl.col(varname)
-    exponent = var.abs().log10().floor()
-    predicate = exponent.abs().ge(thr)
-    mantissa = pl.col("10").pow(exponent)
-    start = var.truediv(mantissa).round(2)
-    end = pl.format("{}E{}", start, exponent)
-    otherwise = var.round_sig_figs(2).cast(pl.String)
+def _as_string(expr: nw.Expr) -> nw.Expr:
+    """String form of a numeric expression.
 
-    return (
-        pl.when(var.eq(0))
-        .then(pl.lit("0"))
-        .when(var.is_infinite())
-        .then(var.cast(pl.String))
-        .when(predicate)
-        .then(end)
-        .otherwise(otherwise)
-        .alias(varname)
-    )
-
-
-def convert_df_scientific(df: pl.LazyFrame, varnames: Iterable[str], thr: int = 4):
+    `pl.format` was doing this before the port; casting reaches the same
+    rendering and is the one thing narwhals offers on every backend.
     """
-    Converts a lazy dataframe to scientific notation.
+    return expr.cast(nw.String)
+
+
+def _floor(expr: nw.Expr) -> nw.Expr:
+    """Floor, as floor division.
+
+    `Expr.floor` only arrived in narwhals 2.20, which needs Python 3.9+ —
+    and this package promises 3.8. `// 1` floors identically on polars,
+    pandas and pyarrow, negatives included.
+    """
+    return expr // 1
+
+
+def _branch(*cases, otherwise: nw.Expr) -> nw.Expr:
+    """A when/then/otherwise chain, written as nesting.
+
+    polars lets `.when()` be chained onto a `Then`; narwhals only grew that
+    in 2.x, so the same shape is expressed by nesting each remaining case
+    inside the previous `otherwise`.
+    """
+    expr = otherwise
+    for condition, value in reversed(cases):
+        expr = nw.when(condition).then(value).otherwise(expr)
+    return expr
+
+
+def convert_df_scientific(df, varnames: Iterable[str], thr: int = 4):
+    """
+    Converts the given columns of a dataframe to scientific notation.
+
+    Backend-agnostic: whatever kind of frame goes in comes back out — a
+    polars LazyFrame stays a polars LazyFrame, a pandas DataFrame stays a
+    pandas DataFrame, a narwhals frame stays a narwhals frame.
 
     Args:
+        df: any narwhals-compatible frame, eager or lazy.
         varnames Iterable[str]: The names of the column to convert.
         thr (int): The threshold exponent for using scientific notation, entries
         white more decimals than 10 ^ thr are converted
 
     Returns:
-        pl.DataFrame: new pl.DataFrame with entries converted
+        A frame of the same kind as `df`, with the named columns replaced by
+        their string renderings.
     """
+    varnames = list(varnames)
+    already_narwhals = isinstance(df, (nw.DataFrame, nw.LazyFrame))
+    frame = df if already_narwhals else nw.from_native(df)
+
     exprs_ex = []
     name_exponents = []
     for varname in varnames:
-        nan = float("nan")
-        var = pl.col(varname).fill_null(nan)  # Somewhat hacky way to deal with nulls:
+        var = nw.col(varname).fill_null(NAN)  # Somewhat hacky way to deal with nulls:
         # Convert to nan, which have more methods defined. Otherwise the when - then
         # function will fail
         name_exponent = f"____EXPONENT____{varname}"
         name_exponents.append(name_exponent)
+        # Zero, the infinities and NaN have no meaningful exponent, and all
+        # of them are resolved by an earlier branch when the string is
+        # built — so any placeholder does. It has to be a number rather
+        # than null, though: pandas' int16 cannot hold NA, and leaving the
+        # branch open raised IntCastingNaNError on the first frame that
+        # contained a zero.
+        # 1.0 rather than the value itself for those rows: pandas evaluates
+        # both arms of a when/then, so feeding log() a zero printed
+        # "RuntimeWarning: divide by zero encountered in log" out of an
+        # ordinary show_stats call. log(1) is 0, which is the placeholder
+        # wanted anyway.
+        has_exponent = var.is_finite() & (var != 0)
+        magnitude = _branch((has_exponent, var.abs()), otherwise=nw.lit(1.0))
         exp_ex = (
-            pl.when(var.is_finite(), var.ne(0))
-            .then(var.abs().log10().floor())
+            _branch(
+                (has_exponent, _floor(magnitude.log(base=10))),
+                otherwise=nw.lit(0.0),
+            )
+            .cast(nw.Int16)
             .alias(name_exponent)
-        ).cast(pl.Int16)
+        )
         exprs_ex.append(exp_ex)
-    df = df.with_columns(exprs_ex)
+    frame = frame.with_columns(exprs_ex)
 
     # log10().floor() can land one off near exact powers of ten because of
     # floating-point error, which pushes the mantissa out of [1, 10) and
@@ -59,46 +99,37 @@ def convert_df_scientific(df: pl.LazyFrame, varnames: Iterable[str], thr: int = 
     # range based on the rounded mantissa it actually produces.
     exprs_correct = []
     for varname, name_exponent in zip(varnames, name_exponents):
-        nan = float("nan")
-        var = pl.col(varname).fill_null(nan)
-        var_exponent = pl.col(name_exponent)
-        mantissa = var.abs().truediv(pl.lit(10.0).pow(var_exponent)).round(2)
+        var = nw.col(varname).fill_null(NAN)
+        var_exponent = nw.col(name_exponent)
+        mantissa = (var.abs() / (nw.lit(10.0) ** var_exponent)).round(2)
         corrected = (
-            (
-                pl.when(mantissa.ge(10))
-                .then(var_exponent + 1)
-                .when(mantissa.lt(1) & var.ne(0))
-                .then(var_exponent - 1)
-                .otherwise(var_exponent)
+            _branch(
+                (mantissa >= 10, var_exponent + 1),
+                ((mantissa < 1) & (var != 0), var_exponent - 1),
+                otherwise=var_exponent,
             )
-            .cast(pl.Int16)
+            .cast(nw.Int16)
             .alias(name_exponent)
         )
         exprs_correct.append(corrected)
-    df = df.with_columns(exprs_correct)
+    frame = frame.with_columns(exprs_correct)
 
     exprs_scient = []
     for varname, name_exponent in zip(varnames, name_exponents):
-        nan = float("nan")
-        var = pl.col(varname).fill_null(nan)
-        var_exponent = pl.col(name_exponent)
-        exp_scient = (
-            pl.when(var.is_nan())
-            .then(pl.lit(""))
-            .when(var.is_infinite())
-            .then(var.cast(pl.String))
-            .when(var.eq(0))
-            .then(pl.lit("0.0"))
-            .when(var_exponent.le(thr))
-            .then(var.round(2).cast(pl.String))
-            .otherwise(
-                pl.format(
-                    "{}E{}",
-                    var.truediv(pl.lit(10.0).pow(var_exponent)).round(2),
-                    var_exponent,
-                )
-            )
+        var = nw.col(varname).fill_null(NAN)
+        var_exponent = nw.col(name_exponent)
+        exp_scient = _branch(
+            (var.is_nan(), nw.lit("")),
+            (~var.is_finite(), _as_string(var)),
+            (var == 0, nw.lit("0.0")),
+            (var_exponent <= thr, _as_string(var.round(2))),
+            otherwise=(
+                _as_string((var / (nw.lit(10.0) ** var_exponent)).round(2))
+                + nw.lit("E")
+                + _as_string(var_exponent)
+            ),
         ).alias(varname)
         exprs_scient.append(exp_scient)
 
-    return df.with_columns(exprs_scient).drop(name_exponents)
+    frame = frame.with_columns(exprs_scient).drop(name_exponents)
+    return frame if already_narwhals else frame.to_native()

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -27,7 +27,6 @@ import polars as pl
 import pyarrow as pa
 import pytest
 
-from showstats._utils import convert_df_scientific
 from showstats.showstats import make_stats_tbl, show_stats
 from tests import _golden
 
@@ -86,35 +85,9 @@ def run_without_polars(body: str) -> subprocess.CompletedProcess:
 # pass, so they have moved to test_backends.py, where they belong as
 # ordinary regression tests rather than as a to-do list.
 
-# --------------------------------------------------------------------------
-# Slice 2 — _utils.convert_df_scientific
-#
-# A pure polars expression pipeline today. It is internal, so the target is
-# only that it stops caring which backend it is handed: same frame kind in,
-# same frame kind out. The existing polars assertions in
-# test_scientific_conversion.py stay as they are and go on passing.
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.xfail(
-    strict=True, reason="#37: convert_df_scientific builds polars expressions"
-)
-def test_convert_df_scientific_accepts_pandas():
-    df = pd.DataFrame({"values": [0.1, 10.0, 1000.0, 10000.0, 100000.0]})
-    result = convert_df_scientific(df, ["values"])
-    assert isinstance(result, pd.DataFrame)
-    assert result["values"].tolist() == ["0.1", "10.0", "1000.0", "10000.0", "1.0E5"]
-
-
-@pytest.mark.xfail(
-    strict=True, reason="#37: convert_df_scientific builds polars expressions"
-)
-def test_convert_df_scientific_accepts_narwhals():
-    df = nw.from_native(pl.DataFrame({"values": [0.1, 1e5]}), eager_only=True)
-    result = convert_df_scientific(df, ["values"])
-    assert isinstance(result, nw.DataFrame)
-    assert result["values"].to_list() == ["0.1", "1.0E5"]
-
+# Slice 2 — _utils.convert_df_scientific — is done. Its tests now pass, so
+# they have moved to test_scientific_conversion.py alongside the polars
+# assertions they were written against.
 
 # --------------------------------------------------------------------------
 # Slice 3 — _Table.make_dt

--- a/tests/test_scientific_conversion.py
+++ b/tests/test_scientific_conversion.py
@@ -1,3 +1,5 @@
+import narwhals as nw
+import pandas as pd
 import polars as pl
 
 from showstats._utils import convert_df_scientific
@@ -38,6 +40,39 @@ def test_convert_df_scientific():
     ]
     assert result.get_column("special").to_list() == ["0.0", "inf", "-inf", ""]
     assert result.get_column("null").to_list() == [""] * 4
+
+
+def test_convert_df_scientific_accepts_pandas():
+    """Whatever kind of frame goes in comes back out.
+
+    The conversion used to be a polars expression pipeline, so a pandas
+    frame died on `with_columns`. Nothing but polars ever reached it, but
+    that is exactly what made the LazyFrame in `make_dt` unavoidable.
+    """
+    df = pd.DataFrame({"values": [0.1, 10.0, 1000.0, 10000.0, 100000.0]})
+    result = convert_df_scientific(df, ["values"])
+    assert isinstance(result, pd.DataFrame)
+    assert result["values"].tolist() == ["0.1", "10.0", "1000.0", "10000.0", "1.0E5"]
+
+
+def test_convert_df_scientific_accepts_narwhals():
+    df = nw.from_native(pl.DataFrame({"values": [0.1, 1e5]}), eager_only=True)
+    result = convert_df_scientific(df, ["values"])
+    assert isinstance(result, nw.DataFrame)
+    assert result["values"].to_list() == ["0.1", "1.0E5"]
+
+
+def test_convert_df_scientific_agrees_across_backends():
+    """The strings must not depend on which frame carried the numbers."""
+    values = [0.002, 0.000023241, -1e7, 1000.0, 2343342.0, 3e7, 0.0, 1e-7]
+    polars_out = (
+        convert_df_scientific(pl.DataFrame({"v": values}).lazy(), ["v"])
+        .collect()
+        .get_column("v")
+        .to_list()
+    )
+    pandas_out = convert_df_scientific(pd.DataFrame({"v": values}), ["v"])["v"].tolist()
+    assert polars_out == pandas_out
 
 
 def test_convert_df_scientific_custom_threshold():

--- a/uv.lock
+++ b/uv.lock
@@ -5869,7 +5869,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "narwhals", specifier = ">=1.0.0" },
+    { name = "narwhals", specifier = ">=1.40.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.5.3" },
     { name = "polars", specifier = ">=0.20.21" },
     { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=10.0.0" },
@@ -5881,7 +5881,7 @@ dev = [
     { name = "build", specifier = ">=1.2.1" },
     { name = "hatchling", specifier = ">=1.25.0" },
     { name = "jupyter", specifier = ">=1.0.0" },
-    { name = "narwhals", specifier = ">=1.0.0" },
+    { name = "narwhals", specifier = ">=1.40.0" },
     { name = "nbclient", specifier = "==0.10.0" },
     { name = "nbformat", specifier = "==5.10.4" },
     { name = "nox", specifier = "==2024.4.15" },


### PR DESCRIPTION
Second implementation slice of the #37 chain. **Stacked on #77**, which is stacked on #76 — the base is that branch, so this diff shows only the slice. GitHub retargets automatically as the stack merges.

**Burndown: 11 → 9.**

```
$ uv run pytest
71 passed, 9 xfailed
```

## What changed

`_utils.convert_df_scientific` was a pure polars expression pipeline. That is what forces `make_dt` to build a `pl.LazyFrame` before calling it, so it has to go before slice 3 can. Ported to narwhals, with the same contract in both directions: **whatever kind of frame goes in comes back out** — polars LazyFrame → polars LazyFrame, pandas → pandas, narwhals → narwhals. The existing call site is untouched, and `test_scientific_conversion.py`'s polars assertions still hold byte for byte.

Also drops `make_scientific`, which was defined in this module and called from nowhere.

## Two narwhals APIs deliberately not used

Both would have read better. Both cost Python 3.8, which `requires-python` still promises:

| wanted | in narwhals since | needs Python | used instead |
|---|---|---|---|
| `Expr.floor()` | 2.20 | ≥ 3.9 | `// 1` |
| `.when()` chained onto a `Then` | 2.x | ≥ 3.9 | nesting, behind a `_branch()` helper |

`// 1` was checked to floor identically to `.floor()` on polars, pandas and pyarrow, negatives included, before being relied on.

## The dependency floor, and #78

The port needs `Expr.log`, which arrived in **narwhals 1.40.0**, so the floor moves `1.0.0 → 1.40.0`.

That prompted checking whether `1.0.0` was ever true. It was not. On `main`, before any slice:

| narwhals | `uv run pytest` on `main` |
|---|---|
| 1.40.0 | **5 failed**, 46 passed |
| 1.45.0 | **5 failed**, 46 passed |
| 2.0.0 | 51 passed |

All five failures are the pandas backend — before 2.0.0, narwhals types pandas `object` columns differently and string columns land in the numerical table. So the real floor is 2.0.0, which requires Python ≥ 3.9, which `requires-python = ">= 3.8"` forbids; `uv sync` rejects the combination outright.

That is a maintainer decision (drop 3.8, or document that pandas needs 3.9+), not something to settle inside a rewrite slice, so it is **#78** and this PR moves the floor only as far as its own code requires.

## Two defects the new cross-backend test caught

`test_convert_df_scientific_agrees_across_backends` asserts polars and pandas produce identical strings for the same numbers. It failed twice before it passed — neither would have been visible from the polars side:

**1. `IntCastingNaNError`.** The exponent column left its `when/then` open, so rows with no meaningful exponent got null. polars holds a null `Int16` happily; pandas raised on the first frame containing a zero. Those rows are resolved by an earlier branch when the string is built, so any number does — it is now `0`.

**2. A warning leaking into ordinary use.** pandas evaluates both arms of a `when/then`, so `log()` saw the zeros regardless of the condition and printed

```
RuntimeWarning: divide by zero encountered in log
```

out of a plain `show_stats(df)` call. The magnitude fed to `log` is now `1.0` on exactly those rows — `log(1)` is `0`, the placeholder wanted anyway. Verified with `uv run pytest -W error::RuntimeWarning`: clean.

## Marker bookkeeping

Two xfails retired, both moved to `test_scientific_conversion.py` next to the polars assertions they were written against, rather than shedding their markers in place:

- `test_convert_df_scientific_accepts_pandas`
- `test_convert_df_scientific_accepts_narwhals`

Neither assertion was weakened in the move. `test_convert_df_scientific_agrees_across_backends` is new — it is the one that found the two defects above.

## Verification

- [x] `uv run pytest` → 71 passed, 9 xfailed; **0 failed, 0 xpassed**
- [x] `uv run pytest -W error::RuntimeWarning` clean
- [x] All 12 golden renderings unchanged — README.md unaffected
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] Suite passes on narwhals 1.40.0 and on current 2.24.0
- [x] `uv.lock` refreshed
- [ ] `uv run nox` — deferred to the final PR per the plan

Next: slice 3, `_Table.make_dt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_