### PR TITLE
Slice 3 — build the formatted table in the caller's backend (#37)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integer statistics from a pandas frame were printed as floats — `Min` as
   `1.0` rather than `1`, `Uniques` as `3.00` rather than `3`. The same data
   now prints identically whatever backend carries it (#37)
+- pyarrow tables with a boolean column raised `ArrowNotImplementedError:
+  Function 'stddev' has no kernel matching input types (bool)` (#37)
+- Booleans printed as `True`/`False` from a pandas frame and `true`/`false`
+  from polars and pyarrow; floats ending in `.0` lost the decimal from a
+  pyarrow table. Both now follow the polars rendering (#37)
 
 ## [0.1.0] - 2026-07-27
 

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -7,7 +7,7 @@ import narwhals as nw
 import polars as pl
 from narwhals.typing import IntoDataFrame
 
-from showstats._utils import convert_df_scientific
+from showstats._utils import _ceil, convert_df_scientific
 
 # The table types show_stats/make_stats_tbl accept. Runtime validation reads
 # the members off this alias via get_args, so the two cannot drift apart.
@@ -150,6 +150,19 @@ def _median_expr(var: str, dtype) -> nw.Expr:
     return col.median()
 
 
+def _std_expr(var: str, dtype) -> nw.Expr:
+    """Standard deviation, for the one dtype pyarrow will not take it on.
+
+    Arrow has no `stddev` kernel for booleans — polars and pandas both do —
+    so it goes through Int8, the same detour `_median_expr` makes. Arrow's
+    `mean` does accept booleans, so only this one needs it.
+    """
+    col = nw.col(var)
+    if dtype == nw.Boolean:
+        return col.cast(nw.Int8).std()
+    return col.std()
+
+
 def _map_table_type_to_var_types(table_type):
     """Maps table type to var types"""
     if table_type == "all":
@@ -205,6 +218,9 @@ class _Table:
                 )
                 quantiles = [q for q in quantiles if q not in (0, 1)]
         self.type = table_type
+        # Remembered so the formatted table can be rebuilt in the same
+        # backend the caller handed in, rather than in polars.
+        self.backend = nw.get_native_namespace(df)
         self.stat_dfs = {}
         self.top_cols = top_cols
         self.quantiles = quantiles
@@ -241,6 +257,8 @@ class _Table:
                         expr = col.quantile(q, interpolation="linear").alias(stat_name)
                     elif function == "median":
                         expr = _median_expr(var, schema[var]).alias(stat_name)
+                    elif function == "std":
+                        expr = _std_expr(var, schema[var]).alias(stat_name)
                     else:
                         expr = getattr(nw.col(var), function)().alias(stat_name)
                     expressions.append(expr)
@@ -279,7 +297,14 @@ class _Table:
             [_quantile_stat_name(q) for q in quantiles] if quantiles else []
         )
 
-    def make_dt(self, var_type: str) -> pl.DataFrame:
+    def make_dt(self, var_type: str):
+        """One row per variable of `var_type`, formatted for printing.
+
+        Returns a frame of the input's own backend — the statistics have
+        been Python values since `__init__` read them out, so the frame is
+        rebuilt here, and rebuilding it in polars was the last thing
+        forcing polars on a pandas or pyarrow user.
+        """
         data = {}
         data["Variable"] = self.vars_map[var_type]
         for fun_name in self.funs_map[var_type]:
@@ -290,9 +315,15 @@ class _Table:
             stat_value = self.stats[name]
             data[fun_name].append(stat_value)
 
-        df = pl.LazyFrame(data)
+        top_names = ()
+        if var_type == "cat":
+            top_cols = self._top_value_columns()
+            top_names = tuple(top_cols)
+            data.update(top_cols)
+
+        df = nw.from_dict(data, backend=self.backend)
         df = df.with_columns(
-            pl.col("null_count").truediv(self.num_rows).mul(100).ceil().cast(pl.Int16)
+            _ceil(nw.col("null_count") / self.num_rows * 100).cast(nw.Int16)
         )
 
         # Some special cases
@@ -302,46 +333,56 @@ class _Table:
             )
         elif var_type in ("num_int", "num_bool"):
             df = convert_df_scientific(
-                df, ["mean", "median", "std"] + self.quantile_stat_names
-            ).with_columns(
-                pl.col("min", "max").cast(pl.String),
-            )
+                df,
+                ["mean", "median", "std"] + self.quantile_stat_names,
+                # Lowercased because pandas renders a boolean as "True" where
+                # polars and pyarrow give "true", and the printed table must
+                # not depend on which backend held the value. A no-op on the
+                # integers that share this branch.
+            ).with_columns(nw.col("min", "max").cast(nw.String).str.to_lowercase())
         elif var_type == "date" or var_type == "datetime":
             df = df.select(
                 "Variable",
                 "null_count",
-                pl.col("median", "min", "max").cast(pl.String).str.slice(0, 19),
+                nw.col("median", "min", "max").cast(nw.String).str.slice(0, 19),
             )
         elif var_type == "null":
             df = df.with_columns(
-                "null_count",
-                pl.lit("").alias("mean"),
-                pl.lit("").alias("std"),
-                pl.lit("").alias("median"),
-                pl.lit("").alias("min"),
-                pl.lit("").alias("max"),
-                *(pl.lit("").alias(name) for name in self.quantile_stat_names),
+                nw.lit("").alias("mean"),
+                nw.lit("").alias("std"),
+                nw.lit("").alias("median"),
+                nw.lit("").alias("min"),
+                nw.lit("").alias("max"),
+                *(nw.lit("").alias(name) for name in self.quantile_stat_names),
             )
         elif var_type == "cat":
-            data = []
-            for var_name in self.vars_map["cat"]:
-                stat_name = f"top_3{self.sep}{var_name}"
-                freq_list = self.stats[stat_name]
-                row = {}
-                for i, dd in enumerate(freq_list):
-                    val, count = dd[var_name], dd["count"]
-                    row[f"Top {i + 1}"] = f"{val} ({count / self.num_rows:.0%})"
-                data.append(row)
-            right = pl.DataFrame(data).fill_null("")
             df = df.select(
                 "Variable",
-                pl.col("null_count").alias("NA%"),
-                pl.col("n_unique").alias("Uniques"),
+                nw.col("null_count").alias("NA%"),
+                nw.col("n_unique").alias("Uniques"),
+                *top_names,
             )
-            for col_name in right.columns:
-                column = right.get_column(col_name)
-                df = df.with_columns(column)
         return df
+
+    def _top_value_columns(self) -> dict:
+        """ "Top 1".."Top 3" columns, as plain Python lists.
+
+        One entry per categorical variable, each already rendered as
+        "<value> (<share>%)". Variables with fewer than three distinct
+        values leave the later columns blank — the polars version got there
+        by building a ragged frame and filling its nulls, which needs a
+        second frame; padding the lists reaches the same place and keeps
+        every column a plain string column on every backend.
+        """
+        columns = {}
+        variables = self.vars_map["cat"]
+        for position, var_name in enumerate(variables):
+            freq_list = self.stats[f"top_3{self.sep}{var_name}"]
+            for i, dd in enumerate(freq_list):
+                val, count = dd[var_name], dd["count"]
+                column = columns.setdefault(f"Top {i + 1}", [""] * len(variables))
+                column[position] = f"{val} ({count / self.num_rows:.0%})"
+        return columns
 
     def form_stat_df(self, table_type):
         """
@@ -367,7 +408,13 @@ class _Table:
 
         if len(subdfs) == 0:
             return
-        stat_df = pl.concat(subdfs)
+        # Temporary seam: make_dt now returns a frame in the caller's own
+        # backend, while everything below is still polars. Arrow is the one
+        # exchange format every backend narwhals supports can produce, and
+        # by this point every column is a string or an Int16, so the
+        # round-trip is faithful. Slice 4 of #37 removes it along with the
+        # polars assembly it feeds.
+        stat_df = pl.concat([pl.from_arrow(sub.to_arrow()).lazy() for sub in subdfs])
 
         if table_type == "num":
             if self.quantile_framing:

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -26,6 +26,30 @@ def _floor(expr: nw.Expr) -> nw.Expr:
     return expr // 1
 
 
+def _float_as_string(expr: nw.Expr) -> nw.Expr:
+    """String form of a float, with the trailing ".0" kept.
+
+    Arrow's double-to-string cast drops it — 3.0 becomes "3" where polars
+    and pandas give "3.0" — so without this the printed table would depend
+    on which backend happened to hold the number. polars is the reference,
+    because README.md is generated from it.
+
+    Only meaningful for finite values. Infinities and NaN reach a "no
+    decimal point" verdict here too, but every caller resolves those in an
+    earlier branch, so the "inf.0" this would produce is never selected.
+    """
+    text = expr.cast(nw.String)
+    return _branch(
+        (text.str.contains(".", literal=True), text),
+        otherwise=nw.concat_str([text, nw.lit(".0")]),
+    )
+
+
+def _ceil(expr: nw.Expr) -> nw.Expr:
+    """Ceiling, via `_floor`, for the same version reason."""
+    return -((-expr) // 1)
+
+
 def _branch(*cases, otherwise: nw.Expr) -> nw.Expr:
     """A when/then/otherwise chain, written as nesting.
 
@@ -122,11 +146,16 @@ def convert_df_scientific(df, varnames: Iterable[str], thr: int = 4):
             (var.is_nan(), nw.lit("")),
             (~var.is_finite(), _as_string(var)),
             (var == 0, nw.lit("0.0")),
-            (var_exponent <= thr, _as_string(var.round(2))),
-            otherwise=(
-                _as_string((var / (nw.lit(10.0) ** var_exponent)).round(2))
-                + nw.lit("E")
-                + _as_string(var_exponent)
+            (var_exponent <= thr, _float_as_string(var.round(2))),
+            # concat_str rather than `a + "E" + b`: pyarrow has no `add`
+            # kernel for two strings, so the operator form raised
+            # ArrowNotImplementedError there.
+            otherwise=nw.concat_str(
+                [
+                    _float_as_string((var / (nw.lit(10.0) ** var_exponent)).round(2)),
+                    nw.lit("E"),
+                    _as_string(var_exponent),
+                ]
             ),
         ).alias(varname)
         exprs_scient.append(exp_scient)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -18,6 +18,8 @@ MIXED_PL = pl.DataFrame(
     {
         "int_col": [1, 2, 3, 4, 5],
         "float_col": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "big_col": [1e-7, 1.0, 12345.0, 9.87e9, 3.0],
+        "bool_col": [True, False, True, False, True],
         "str_col": ["a", "b", "c", "a", "b"],
     }
 )
@@ -81,7 +83,8 @@ def test_pyarrow_backend_basic():
     raised AttributeError.
     """
     result = make_stats_tbl(MIXED_PA, "num")
-    assert stats_frame(result).shape[0] == 2
+    # int_col, float_col, big_col, bool_col — str_col is not numerical
+    assert stats_frame(result).shape[0] == 4
 
 
 def test_pyarrow_backend_categorical_top_values():
@@ -100,17 +103,43 @@ def test_pyarrow_backend_all_types(capsys):
     "df",
     [pytest.param(MIXED_PD, id="pandas"), pytest.param(MIXED_PA, id="pyarrow")],
 )
-def test_rendering_does_not_depend_on_the_input_backend(capsys, df):
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"table_type": "all"}, id="all"),
+        pytest.param({"table_type": "num"}, id="num"),
+        pytest.param({"table_type": "cat"}, id="cat"),
+        pytest.param({"table_type": "num", "quantiles": [0.25, 0.75]}, id="quantiles"),
+        pytest.param(
+            {"table_type": "num", "quantiles": [0.5], "fold_quantiles": False},
+            id="unfolded",
+        ),
+    ],
+)
+def test_rendering_does_not_depend_on_the_input_backend(capsys, df, kwargs):
     """Identical data must print identically whatever frame carries it.
 
-    It did not: pandas input printed int Min/Max as `1.0` and Uniques as
-    `3.00`. Not a rendering bug — reading the aggregate row through pandas'
-    `.iloc[0]` produced a Series of one dtype, so the integer statistics
-    came back as floats before rendering ever saw them.
+    Four separate ways it did not, each caught here rather than by
+    inspection, and each traceable to one backend's idea of how a value
+    becomes text:
+
+    - pandas printed int Min/Max as `1.0` and Uniques as `3.00`, because
+      reading the aggregate row through `.iloc[0]` gave a Series, which
+      has a single dtype.
+    - pyarrow's double-to-string cast drops a trailing `.0`, so `3.0`
+      printed as `3`.
+    - pandas renders a boolean as `True` where polars and pyarrow give
+      `true`.
+    - pyarrow has no `add` kernel for two strings, so building `"1.0E5"`
+      by concatenation raised instead of printing anything at all.
+
+    polars is the reference, since README.md is generated from it — hence
+    comparing against the polars rendering rather than merely checking the
+    two agree with each other.
     """
-    show_stats(df, "all")
+    show_stats(df, **kwargs)
     from_backend = capsys.readouterr().out
-    show_stats(MIXED_PL, "all")
+    show_stats(MIXED_PL, **kwargs)
     assert from_backend == capsys.readouterr().out
 
 

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -10,16 +10,18 @@ README.md embeds this output verbatim.
 None of these are marked `rewrite`. They describe behaviour that must
 survive the rewrite unchanged, so they are expected to pass throughout.
 
-Three current warts are pinned here deliberately rather than fixed:
+Two current warts are pinned here deliberately rather than fixed:
 
 1. `QUANTILES_FOLDED` is missing its Q0 column — polars elides columns that
    do not fit `set_tbl_width_chars=80`, replacing them with `…`. So asking
    for enough quantiles silently drops the minimum.
 2. `TIME` wraps the datetime median onto a second, unaligned line for the
    same reason.
-3. Numbers render differently depending on the input backend — see
-   `test_rewrite.py::test_pandas_renders_like_polars`, which is the xfail
-   that owns that one.
+
+These goldens are all polars input. That the same data prints identically
+from pandas and pyarrow is
+`test_backends.py::test_rendering_does_not_depend_on_the_input_backend`;
+together the two say the rendering is fixed *and* backend-independent.
 
 Changing any of these is a deliberate act: update the golden in its own
 commit, with the reason, plus a changelog entry. Never quietly, alongside

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -21,7 +21,6 @@ import subprocess
 import sys
 import textwrap
 
-import narwhals as nw
 import pandas as pd
 import polars as pl
 import pyarrow as pa
@@ -89,30 +88,8 @@ def run_without_polars(body: str) -> subprocess.CompletedProcess:
 # they have moved to test_scientific_conversion.py alongside the polars
 # assertions they were written against.
 
-# --------------------------------------------------------------------------
-# Slice 3 — _Table.make_dt
-#
-# Builds a pl.LazyFrame per var-type regardless of what came in, which is
-# where the polars dependency re-enters after the stats have been computed
-# through narwhals.
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.xfail(strict=True, reason="#37: make_dt always builds a pl.LazyFrame")
-@pytest.mark.parametrize(
-    ("df", "native_type"),
-    [
-        pytest.param(MIXED_PD, pd.DataFrame, id="pandas"),
-        pytest.param(MIXED_PA, pa.Table, id="pyarrow"),
-    ],
-)
-def test_make_dt_follows_the_input_backend(df, native_type):
-    from showstats._table import _Table
-
-    table = _Table(df, "num")
-    result = table.make_dt("num_int")
-    assert isinstance(nw.to_native(nw.from_native(result)), native_type)
-
+# Slice 3 — _Table.make_dt — is done. Its tests now pass, so they have
+# moved to test_table.py, next to the other make_dt assertions.
 
 # --------------------------------------------------------------------------
 # Slice 4 — _Table.form_stat_df and the return type

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,9 +1,17 @@
 import warnings
 
+import narwhals as nw
+import pandas as pd
 import polars as pl
+import pyarrow as pa
 import pytest
 
 from showstats._table import _WARNED_ONCE, _Table
+
+
+def as_native(frame):
+    """The backend object behind whatever make_dt returned."""
+    return nw.to_native(nw.from_native(frame))
 
 
 @pytest.fixture(autouse=True)
@@ -17,17 +25,10 @@ def _reset_warning_registry():
 def test_make_dt_num(sample_df):
     _table = _Table(sample_df, "all")
 
-    df_num_float = _table.make_dt("num_float")
-    df_num_int = _table.make_dt("num_int")
-    df_num_bool = _table.make_dt("num_bool")
-    df_datetime = _table.make_dt("datetime")
-    df_date = _table.make_dt("date")
-
-    assert isinstance(df_num_int, pl.LazyFrame)
-    assert isinstance(df_num_float, pl.LazyFrame)
-    assert isinstance(df_num_bool, pl.LazyFrame)
-    assert isinstance(df_date, pl.LazyFrame)
-    assert isinstance(df_datetime, pl.LazyFrame)
+    frames = {
+        var_type: nw.from_native(_table.make_dt(var_type))
+        for var_type in ("num_float", "num_int", "num_bool", "date", "datetime")
+    }
 
     desired_names = [
         "Variable",
@@ -39,40 +40,38 @@ def test_make_dt_num(sample_df):
         "max",
     ]
     desired_dtypes = [
-        pl.String,
-        pl.Int16,
-        pl.String,
-        pl.String,
-        pl.String,
-        pl.String,
-        pl.String,
+        nw.String,
+        nw.Int16,
+        nw.String,
+        nw.String,
+        nw.String,
+        nw.String,
+        nw.String,
     ]
 
-    df_num_float = df_num_float.collect()
-    assert df_num_float.columns == desired_names
-    assert df_num_float.dtypes == desired_dtypes
+    for var_type in ("num_float", "num_int", "num_bool"):
+        frame = frames[var_type]
+        assert frame.columns == desired_names, var_type
+        assert list(frame.schema.values()) == desired_dtypes, var_type
 
-    df_num_int = df_num_int.collect()
-    assert df_num_int.columns == desired_names
-    assert df_num_int.dtypes == desired_dtypes
-
-    df_num_bool = df_num_bool.collect()
-    assert df_num_bool.columns == desired_names
-    assert df_num_bool.dtypes == desired_dtypes
-
-    df_datetime = df_datetime.collect()
-    assert df_datetime.columns == ["Variable", "null_count", "median", "min", "max"]
-    assert df_datetime.dtypes == [pl.String, pl.Int16, pl.String, pl.String, pl.String]
+    for var_type in ("date", "datetime"):
+        frame = frames[var_type]
+        assert frame.columns == ["Variable", "null_count", "median", "min", "max"]
+        assert list(frame.schema.values()) == [
+            nw.String,
+            nw.Int16,
+            nw.String,
+            nw.String,
+            nw.String,
+        ]
 
 
 def test_make_dt_cat(sample_df):
     _table = _Table(sample_df, "cat")
 
-    df_cat = _table.make_dt("cat")
+    df_cat = nw.from_native(_table.make_dt("cat"))
 
-    assert isinstance(df_cat, pl.LazyFrame)
-
-    desired_names = [
+    assert df_cat.columns == [
         "Variable",
         "NA%",
         "Uniques",
@@ -80,11 +79,36 @@ def test_make_dt_cat(sample_df):
         "Top 2",
         "Top 3",
     ]
-    desired_dtypes = [pl.String, pl.Int16, pl.Int64, pl.String, pl.String, pl.String]
+    assert list(df_cat.schema.values()) == [
+        nw.String,
+        nw.Int16,
+        nw.Int64,
+        nw.String,
+        nw.String,
+        nw.String,
+    ]
 
-    df_cat = df_cat.collect()
-    assert df_cat.columns == desired_names
-    assert df_cat.dtypes == desired_dtypes
+
+@pytest.mark.parametrize(
+    ("frame", "native_type"),
+    [
+        pytest.param(pl.DataFrame, pl.DataFrame, id="polars"),
+        pytest.param(pd.DataFrame, pd.DataFrame, id="pandas"),
+        pytest.param(pa.table, pa.Table, id="pyarrow"),
+    ],
+)
+def test_make_dt_follows_the_input_backend(frame, native_type):
+    """The formatted frame is built in the caller's own backend.
+
+    It used to be a `pl.LazyFrame` regardless — the statistics have been
+    plain Python values since `__init__` read them out, so rebuilding them
+    in polars was gratuitous, and it was the last thing forcing polars on
+    a pandas or pyarrow user before rendering.
+    """
+    data = {"int_col": [1, 2, 3, 4, 5], "float_col": [1.5, 2.5, 3.5, 4.5, 5.5]}
+    table = _Table(frame(data), "num")
+    assert isinstance(as_native(table.make_dt("num_int")), native_type)
+    assert isinstance(as_native(table.make_dt("num_float")), native_type)
 
 
 def test_that_statistics_are_correct(sample_df):


### PR DESCRIPTION
Third implementation slice of the #37 chain. **Stacked on #79 → #77 → #76.**

**Burndown: 9 → 7.**

```
$ uv run pytest
82 passed, 7 xfailed
```

## What changed

`make_dt` built a `pl.LazyFrame` per var-type regardless of what came in. The statistics have been plain Python values since `__init__` read them out, so rebuilding them in polars was gratuitous — and it was the last thing forcing polars on a pandas or pyarrow user before rendering. It now builds through `nw.from_dict` in the input's own backend, remembered as `_Table.backend`.

The categorical top-3 columns are built as padded Python lists rather than a ragged second frame whose nulls get filled. Same output, no second frame, and every column stays a plain string column on every backend.

## The seam

`form_stat_df` is still polars assembly, so this slice leaves a marked seam:

```python
# Temporary seam: make_dt now returns a frame in the caller's own backend,
# while everything below is still polars. Arrow is the one exchange format
# every backend narwhals supports can produce, and by this point every
# column is a string or an Int16, so the round-trip is faithful.
# Slice 4 of #37 removes it along with the polars assembly it feeds.
stat_df = pl.concat([pl.from_arrow(sub.to_arrow()).lazy() for sub in subdfs])
```

## Four backend divergences, all found by test rather than by reading

I widened `test_rendering_does_not_depend_on_the_input_backend` — bool and large-magnitude columns in the fixture, and five parameter combinations (`all`, `num`, `cat`, folded quantiles, unfolded quantiles) × pandas and pyarrow. Every one of these came out of that, and none would have shown up from the polars side:

| divergence | fix |
|---|---|
| pyarrow has no `add` kernel for two strings, so `"1.0E5"` could not be built by concatenation — it **raised**, printing nothing at all | `nw.concat_str` |
| Arrow's double→string cast drops a trailing `.0`, so `3.0` printed as `3` | `_float_as_string` normalises it |
| pandas renders a boolean as `True` where polars and pyarrow give `true` | min/max strings lowercased |
| Arrow has no `stddev` kernel for booleans, so a pyarrow table with a boolean column **raised** | `_std_expr` takes the Int8 detour `_median_expr` already took |

polars is the reference in each case, because README.md is generated from it and the goldens pin it.

## A pre-existing test whose expectation had to change

`test_make_dt_num` and `test_make_dt_cat` asserted `isinstance(df, pl.LazyFrame)`, compared dtypes against `pl.String`/`pl.Int16`, and called `.collect()`. All of that encodes the polars internal #37 exists to remove — the *shape* of the frame is the contract, the library holding it is not.

Per the plan, that is **its own commit** (`a03ca54`), ahead of the implementation rather than behind it, so the history reads as TDD: state the expectation, then meet it. That commit is red on its own by design; the tree is green at the tip and at every other commit. Same column names, same dtypes, same coverage — nothing weakened, and the polars leg the old xfail could not carry (it already passed) is now covered too.

`Expr.ceil`, like `Expr.floor`, needs narwhals 2.20 and therefore Python 3.9, so `_ceil` goes through floor division for the same reason as `_floor` — see #78.

## Verification

- [x] `uv run pytest` → 82 passed, 7 xfailed; **0 failed, 0 xpassed**
- [x] All 12 golden renderings unchanged — README.md unaffected
- [x] pandas and pyarrow now render byte-identically to polars across all five parameter combinations
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [ ] `uv run nox` — deferred to the final PR per the plan

Next: slice 4, `form_stat_df` and the `top_cols` ordering — which also removes the seam above.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_