### PR TITLE
Slice 4 — assemble the stats table in narwhals; make_stats_tbl returns the input type (#37)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `make_stats_tbl` now returns a frame of the same kind as its
+  input — pandas in, pandas out; pyarrow in, pyarrow out — instead of always
+  returning a polars DataFrame. Code that called polars methods on the
+  result of a non-polars input needs updating (#37)
 - Minimum `narwhals` raised from 1.0.0 to 1.40.0, which is where
   `Expr.log` arrived. The old floor was never checked against anything —
   see #78, the suite in fact needs 2.0.0 for the pandas backend (#37)

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -7,7 +7,7 @@ import narwhals as nw
 import polars as pl
 from narwhals.typing import IntoDataFrame
 
-from showstats._utils import _ceil, convert_df_scientific
+from showstats._utils import _branch, _ceil, convert_df_scientific
 
 # The table types show_stats/make_stats_tbl accept. Runtime validation reads
 # the members off this alias via get_args, so the two cannot drift apart.
@@ -119,16 +119,20 @@ def _map_cols_and_funs_for_var_type(
 _MAX_VAR_NAME_LEN = 30
 
 
-def _truncate_long_strings(expr: pl.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> pl.Expr:
+def _truncate_long_strings(expr: nw.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> nw.Expr:
     """Truncates strings longer than max_len, marking the cut with an ellipsis.
 
     Long variable names otherwise wrap onto a new, misaligned line when the
     printed table exceeds its configured width.
+
+    "Longer than max_len" is asked as "does slicing to max_len change it",
+    which sidesteps `str.len_chars` — that only arrived in a narwhals new
+    enough to need Python 3.9 (#78) — and asks the question in exactly the
+    units the slice below will use.
     """
-    return (
-        pl.when(expr.str.len_chars().gt(max_len))
-        .then(expr.str.slice(0, max_len - 1) + "…")
-        .otherwise(expr)
+    return _branch(
+        (expr.str.slice(0, max_len) == expr, expr),
+        otherwise=nw.concat_str([expr.str.slice(0, max_len - 1), nw.lit("…")]),
     )
 
 
@@ -408,13 +412,7 @@ class _Table:
 
         if len(subdfs) == 0:
             return
-        # Temporary seam: make_dt now returns a frame in the caller's own
-        # backend, while everything below is still polars. Arrow is the one
-        # exchange format every backend narwhals supports can produce, and
-        # by this point every column is a string or an Int16, so the
-        # round-trip is faithful. Slice 4 of #37 removes it along with the
-        # polars assembly it feeds.
-        stat_df = pl.concat([pl.from_arrow(sub.to_arrow()).lazy() for sub in subdfs])
+        stat_df = nw.concat(subdfs, how="vertical")
 
         if table_type == "num":
             if self.quantile_framing:
@@ -423,46 +421,46 @@ class _Table:
                 # explicit 0.5 replaces the Median column outright, since Q50
                 # is the same statistic under the same interpolation.
                 median_col = (
-                    [] if 0.5 in self.quantiles else [pl.col("median").alias("Median")]
+                    [] if 0.5 in self.quantiles else [nw.col("median").alias("Median")]
                 )
                 tail_cols = [
                     *median_col,
-                    pl.col("min").alias("Q0"),
+                    nw.col("min").alias("Q0"),
                     *(
-                        pl.col(_quantile_stat_name(q)).alias(_quantile_label(q))
+                        nw.col(_quantile_stat_name(q)).alias(_quantile_label(q))
                         for q in self.quantiles
                     ),
-                    pl.col("max").alias("Q100"),
+                    nw.col("max").alias("Q100"),
                 ]
             else:
                 # Named stats keep their names; any requested quantiles are
                 # appended alongside them. Min and Max sit last: they are the
                 # extremes, so the central statistics come first.
                 tail_cols = [
-                    pl.col("median").alias("Median"),
+                    nw.col("median").alias("Median"),
                     *(
-                        pl.col(_quantile_stat_name(q)).alias(_quantile_label(q))
+                        nw.col(_quantile_stat_name(q)).alias(_quantile_label(q))
                         for q in (self.quantiles or [])
                     ),
-                    pl.col("min").alias("Min"),
-                    pl.col("max").alias("Max"),
+                    nw.col("min").alias("Min"),
+                    nw.col("max").alias("Max"),
                 ]
             stat_df = stat_df.select(
-                pl.col("Variable").alias(name_var),
-                pl.col("null_count").alias("NA%"),
-                pl.col("mean").alias("Avg"),
-                pl.col("std").alias("SD"),
+                nw.col("Variable").alias(name_var),
+                nw.col("null_count").alias("NA%"),
+                nw.col("mean").alias("Avg"),
+                nw.col("std").alias("SD"),
                 *tail_cols,
             )
         elif table_type == "cat":
             stat_df = stat_df.rename({"Variable": name_var})
         elif table_type == "time":
             stat_df = stat_df.select(
-                pl.col("Variable").alias(name_var),
-                pl.col("null_count").alias("NA%"),
-                pl.col("median").alias("Median"),
-                pl.col("min").alias("Min"),
-                pl.col("max").alias("Max"),
+                nw.col("Variable").alias(name_var),
+                nw.col("null_count").alias("NA%"),
+                nw.col("median").alias("Median"),
+                nw.col("min").alias("Min"),
+                nw.col("max").alias("Max"),
             )
 
         if self.top_cols is not None:  # Put top_cols at front
@@ -472,18 +470,52 @@ class _Table:
             new_order = self.top_cols + [
                 var for var in all_columns_in_order if var not in self.top_cols
             ]
-            stat_df = stat_df.with_columns(
-                pl.col(name_var).cast(pl.Enum(new_order))
-            ).sort(name_var)
+            # The polars version cast the column to pl.Enum(new_order) and
+            # sorted on it, letting the categorical ordering do the work.
+            # narwhals has no equivalent, so the rank is made explicit: map
+            # each name to its position, sort by that, drop it again. Same
+            # result, and it no longer depends on the name column being of
+            # a particular dtype afterwards.
+            rank = "____ORDER____"
+            stat_df = (
+                stat_df.with_columns(
+                    nw.col(name_var)
+                    .replace_strict(
+                        new_order, list(range(len(new_order))), return_dtype=nw.Int32
+                    )
+                    .alias(rank)
+                )
+                .sort(rank)
+                .drop(rank)
+            )
 
         stat_df = stat_df.with_columns(
-            _truncate_long_strings(pl.col(name_var).cast(pl.String)).alias(name_var)
+            _truncate_long_strings(nw.col(name_var).cast(nw.String)).alias(name_var)
         )
 
-        self.stat_dfs[table_type] = stat_df.collect()
+        # Rebuilt so the row labels are fresh. pandas carries each
+        # subframe's own index through a vertical concat, so the assembled
+        # table came back indexed (0, 0, 0) — three rows all addressed as
+        # row 0. Cheap: one row per column of the input.
+        self.stat_dfs[table_type] = nw.from_dict(
+            {name: stat_df[name].to_list() for name in stat_df.columns},
+            schema=stat_df.schema,
+            backend=self.backend,
+        )
 
     def show_one_table(self, table_type):
         if table_type in self.stat_dfs:
+            # Temporary seam: the table is assembled in the caller's own
+            # backend now, but printing is still pl.Config, and there is no
+            # narwhals renderer to hand it to. Arrow is the one exchange
+            # format every narwhals backend can produce, and every column
+            # here is a string or an Int16, so the round-trip is faithful.
+            # Slice 5 of #37 replaces the printing and removes this.
+            frame = self.stat_dfs[table_type]
+            # select() rather than the bare conversion: a pandas frame
+            # carries its index into Arrow as __index_level_0__, which
+            # would print as an extra column.
+            printable = pl.from_arrow(frame.to_arrow()).select(frame.columns)
             with pl.Config(
                 tbl_hide_dataframe_shape=True,
                 tbl_formatting="NOTHING",
@@ -495,7 +527,7 @@ class _Table:
                 set_fmt_float="full",
                 set_tbl_width_chars=80,
             ):
-                print(self.stat_dfs[table_type])
+                print(printable)
         else:
             if table_type == "num":
                 print("No numerical columns found")

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -61,10 +61,16 @@ def make_stats_tbl(
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
     fold_quantiles: bool = True,
-) -> None:
+) -> IntoDataFrame | None:
     """
     Builds table of summary statistics for the given DataFrame, configured
     for for optimal readability.
+
+    The result is a frame of the same kind as the input — a polars frame in
+    gives a polars frame back, pandas gives pandas, and so on — so callers
+    do not take on a dependency on some other dataframe library just to
+    read the summary. Returns None when the input has no columns of the
+    requested type.
 
     Args:
         df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
@@ -99,4 +105,7 @@ def make_stats_tbl(
     _table = _Table(df, table_type, top_cols, quantiles, fold_quantiles)
     _table.form_stat_df(table_type)
     # Return None if no columns of this type were found
-    return _table.stat_dfs.get(table_type, None)
+    stat_df = _table.stat_dfs.get(table_type, None)
+    if stat_df is None:
+        return None
+    return stat_df.to_native()

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -1,5 +1,24 @@
+import pandas as pd
+import polars as pl
+import pyarrow as pa
+import pytest
+
 from showstats.showstats import make_stats_tbl
 from tests.helpers import stats_frame
+
+MIXED_PL = pl.DataFrame(
+    {
+        "int_col": [1, 2, 3, 4, 5],
+        "float_col": [1.5, 2.5, 3.5, 4.5, 5.5],
+        "str_col": ["a", "b", "c", "a", "b"],
+    }
+)
+
+BACKENDS = [
+    pytest.param(MIXED_PL, pl.DataFrame, id="polars"),
+    pytest.param(MIXED_PL.to_pandas(), pd.DataFrame, id="pandas"),
+    pytest.param(MIXED_PL.to_arrow(), pa.Table, id="pyarrow"),
+]
 
 
 def test_make_stats_tbl(sample_df):
@@ -15,3 +34,38 @@ def test_make_stats_tbl_quantiles(sample_df):
     res_num = stats_frame(make_stats_tbl(sample_df, "num", quantiles=[0.25, 0.75]))
     assert "Q25" in res_num.columns
     assert "Q75" in res_num.columns
+
+
+@pytest.mark.parametrize(("df", "native_type"), BACKENDS)
+def test_make_stats_tbl_returns_the_input_type(df, native_type):
+    """The return follows the input, rather than always being polars.
+
+    Signed off on #37: a dataframe-agnostic library that hands back one
+    particular library's frame makes its caller depend on that library.
+    """
+    assert isinstance(make_stats_tbl(df, "num"), native_type)
+
+
+def test_make_stats_tbl_pandas_result_is_indexed_from_zero():
+    """A returned pandas frame must be usable as a pandas frame.
+
+    The table is assembled from one subframe per var-type, and pandas
+    carries each subframe's own index through a vertical concat — so the
+    result came back indexed (0, 0), where `.loc[0]` returns two rows.
+    """
+    result = make_stats_tbl(MIXED_PL.to_pandas(), "num")
+    assert list(result.index) == [0, 1]
+
+
+@pytest.mark.parametrize(("df", "native_type"), BACKENDS)
+def test_top_cols_ordering(df, native_type):
+    """top_cols used to work by casting to pl.Enum and sorting.
+
+    narwhals has no categorical-ordering trick to lean on, so the rank is
+    made explicit — and it has to keep working, natively, whatever frame
+    was passed in.
+    """
+    result = make_stats_tbl(df, "num", top_cols="float_col")
+    assert isinstance(result, native_type)
+    frame = stats_frame(result)
+    assert frame[frame.columns[0]].to_list() == ["float_col", "int_col"]

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -21,12 +21,10 @@ import subprocess
 import sys
 import textwrap
 
-import pandas as pd
 import polars as pl
-import pyarrow as pa
 import pytest
 
-from showstats.showstats import make_stats_tbl, show_stats
+from showstats.showstats import show_stats
 from tests import _golden
 
 pytestmark = pytest.mark.rewrite
@@ -91,44 +89,8 @@ def run_without_polars(body: str) -> subprocess.CompletedProcess:
 # Slice 3 — _Table.make_dt — is done. Its tests now pass, so they have
 # moved to test_table.py, next to the other make_dt assertions.
 
-# --------------------------------------------------------------------------
-# Slice 4 — _Table.form_stat_df and the return type
-#
-# make_stats_tbl returns a pl.DataFrame whatever it is given. The agreed
-# outcome (see the sign-off on #37) is that the return follows the input.
-# The polars case already holds today and so is asserted in
-# test_make_tbl.py, unmarked, rather than here.
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.xfail(
-    strict=True, reason="#37: form_stat_df collects to polars whatever came in"
-)
-@pytest.mark.parametrize(
-    ("df", "native_type"),
-    [
-        pytest.param(MIXED_PD, pd.DataFrame, id="pandas"),
-        pytest.param(MIXED_PA, pa.Table, id="pyarrow"),
-    ],
-)
-def test_make_stats_tbl_returns_the_input_type(df, native_type):
-    assert isinstance(make_stats_tbl(df, "num"), native_type)
-
-
-@pytest.mark.xfail(
-    strict=True, reason="#37: form_stat_df orders top_cols by casting to pl.Enum"
-)
-def test_top_cols_ordering_survives_the_backend_change():
-    """top_cols currently works by casting to pl.Enum and sorting.
-
-    narwhals has no equivalent, so the ordering needs a different
-    implementation — and it has to keep working, natively, for a
-    non-polars input.
-    """
-    result = make_stats_tbl(MIXED_PD, "num", top_cols="float_col")
-    assert isinstance(result, pd.DataFrame)
-    assert result[result.columns[0]].tolist() == ["float_col", "int_col"]
-
+# Slice 4 — _Table.form_stat_df and the return type — is done. Its tests
+# now pass, so they have moved to test_make_tbl.py.
 
 # --------------------------------------------------------------------------
 # Slice 5 — _Table.show_one_table

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -115,7 +115,7 @@ def test_that_statistics_are_correct(sample_df):
     table = _Table(sample_df, "num")
     table.form_stat_df("num")
     stat_df = table.stat_dfs["num"]
-    var_0 = pl.col(stat_df.columns[0])
+    var_0 = nw.col(stat_df.columns[0])
     assert stat_df.filter(var_0 == "float_mean_2").item(0, "Avg") == "2.0"
     assert stat_df.filter(var_0 == "float_std_2").item(0, "SD") == "2.0"
     assert stat_df.filter(var_0 == "float_min_-7").item(0, "Min") == "-7.0"
@@ -141,11 +141,11 @@ def test_top_cols(sample_df):
     name_col_0 = table_top_cols.stat_dfs["num"].columns[0]
     col_0_top_cols = table_top_cols.stat_dfs["num"].get_column(name_col_0)
     col_0_no_top_cols = table_no_top_cols.stat_dfs["num"].get_column(name_col_0)
-    assert col_0_top_cols.equals(col_0_no_top_cols) is False
+    assert col_0_top_cols.to_list() != col_0_no_top_cols.to_list()
     assert sorted(col_0_top_cols.to_list()) == sorted(col_0_no_top_cols.to_list())
 
     assert (
-        table_no_top_cols.stat_dfs["num"].height
+        table_no_top_cols.stat_dfs["num"].shape[0]
         == sample_df.select(
             pl.selectors.exclude(
                 pl.Enum, pl.String, pl.Categorical, pl.Date, pl.Datetime
@@ -190,7 +190,7 @@ def test_char_table():
     _table = _Table(df, "cat")
     _table.form_stat_df("cat")
     stat_df = _table.stat_dfs["cat"]
-    col0 = pl.col(stat_df.columns[0])
+    col0 = nw.col(stat_df.columns[0])
 
     assert _table.stat_dfs["cat"].filter(col0 == "x1").item(0, "NA%") == 0
     assert _table.stat_dfs["cat"].filter(col0 == "x1").item(0, "Uniques") == 1
@@ -236,7 +236,7 @@ def test_quantiles(sample_df):
     assert "Q10" in stat_df.columns
     assert "Q90" in stat_df.columns
 
-    var_0 = pl.col(stat_df.columns[0])
+    var_0 = nw.col(stat_df.columns[0])
     q10 = float(stat_df.filter(var_0 == "int_col").item(0, "Q10"))
     q90 = float(stat_df.filter(var_0 == "int_col").item(0, "Q90"))
     assert q10 < q90


### PR DESCRIPTION
Fourth implementation slice of the #37 chain. **Stacked on #80 → #79 → #77 → #76.**

**Burndown: 7 → 4.** Only slice 5 (rendering) is left.

```
$ uv run pytest
89 passed, 4 xfailed
```

## ⚠️ This is the breaking change

`make_stats_tbl` now returns **a frame of the same kind as its input** — pandas in, pandas out; pyarrow in, pyarrow out — instead of always a `pl.DataFrame`. That is the outcome you signed off on in [#37](https://github.com/matthiaskaeding/showstats/issues/37#issuecomment-5096809806), and it is why PR #73 migrated the assertions first. Changelog entry added under **Breaking**.

`show_stats` is unaffected; it prints.

## What changed

`form_stat_df` concatenated, selected, renamed and sorted in polars and then collected. All of it now goes through narwhals.

**`top_cols` needed a new implementation, not a translation.** polars did the ordering by casting the name column to `pl.Enum(new_order)` and sorting on the categorical order. narwhals has no equivalent, so the rank is now explicit — map each name to its position, sort by that, drop it. A side benefit: the name column's dtype no longer depends on whether `top_cols` was passed.

**`_truncate_long_strings`** asks *"is this longer than max_len"* as *"does slicing to max_len change it"*. That avoids `str.len_chars`, which needs a narwhals new enough to require Python 3.9 (#78) — and it asks the question in the same units as the slice that follows, which is arguably more correct anyway.

## Two things that only appear once you assemble in the caller's backend

Both are pandas-index problems, and neither is visible from polars:

1. **The returned pandas frame was indexed `(0, 0, 0)`.** One index per subframe, preserved through the vertical concat — so `result.loc[0]` returned three rows. The table is rebuilt from its own columns at the end; cheap, at one row per input column. Pinned by `test_make_stats_tbl_pandas_result_is_indexed_from_zero`.
2. **A pandas index travels into Arrow as `__index_level_0__`** and printed as a literal extra column through the rendering seam. That seam now selects the frame's own columns.

## The remaining seam

`show_one_table` still prints through `pl.Config`, and there is no narwhals renderer to hand the table to — so it converts via Arrow, marked as temporary. Slice 5 replaces the printing and removes it. The seam from slice 3 (`form_stat_df`) is gone.

## A pre-existing test whose expectation had to change

`test_that_statistics_are_correct`, `test_top_cols` and `test_char_table` reached into `_Table.stat_dfs` with `pl.col`, `Series.equals` and `.height`. Those only ever worked because `form_stat_df` collected to polars whatever came in — the very thing the agreed return type removes. So this is an expectation change #37 **predicted**, not a regression.

Same assertions, same values, expressed against the frame's own API, in its own commit (`77a206e`) ahead of the implementation.

## Verification

- [x] `uv run pytest` → 89 passed, 4 xfailed; **0 failed, 0 xpassed**
- [x] All 12 golden renderings unchanged — README.md unaffected
- [x] pandas and pyarrow still render byte-identically to polars across all five parameter combinations
- [x] `top_cols` ordering tested on all three backends, natively
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [ ] `uv run nox` — deferred to the final PR per the plan

Next: slice 5 — the hand-written formatter, against the goldens from #76.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_