### PR TITLE
Slice 5 — print without polars; burndown reaches zero (#37)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tables are printed by showstats itself rather than by polars' dataframe
+  formatter. The layout is unchanged; two of polars' display behaviours are
+  not reproduced, both listed under Fixed below (#37)
 - **Breaking:** `make_stats_tbl` now returns a frame of the same kind as its
   input — pandas in, pandas out; pyarrow in, pyarrow out — instead of always
   returning a polars DataFrame. Code that called polars methods on the
@@ -30,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Booleans printed as `True`/`False` from a pandas frame and `true`/`false`
   from polars and pyarrow; floats ending in `.0` lost the decimal from a
   pyarrow table. Both now follow the polars rendering (#37)
+- Tables with more than eight columns silently dropped one and printed `…`
+  in its place — so `quantiles=[0.25, 0.5, 0.75]` lost the `Q0` column, and
+  the quantiles example in the README lost `Median`. Every column is now
+  shown (#37)
+- A value wider than the table wrapped onto a second, unaligned line, which
+  is how a datetime median printed. Columns are now sized to their contents,
+  so a wide table is wide rather than misaligned (#37)
 
 ## [0.1.0] - 2026-07-27
 

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -4,10 +4,15 @@ import warnings
 from typing import Iterable, Literal
 
 import narwhals as nw
-import polars as pl
 from narwhals.typing import IntoDataFrame
 
-from showstats._utils import _branch, _ceil, convert_df_scientific
+from showstats._utils import (
+    TABLE_WIDTH,
+    _branch,
+    _ceil,
+    convert_df_scientific,
+    render_table,
+)
 
 # The table types show_stats/make_stats_tbl accept. Runtime validation reads
 # the members off this alias via get_args, so the two cannot drift apart.
@@ -505,29 +510,7 @@ class _Table:
 
     def show_one_table(self, table_type):
         if table_type in self.stat_dfs:
-            # Temporary seam: the table is assembled in the caller's own
-            # backend now, but printing is still pl.Config, and there is no
-            # narwhals renderer to hand it to. Arrow is the one exchange
-            # format every narwhals backend can produce, and every column
-            # here is a string or an Int16, so the round-trip is faithful.
-            # Slice 5 of #37 replaces the printing and removes this.
-            frame = self.stat_dfs[table_type]
-            # select() rather than the bare conversion: a pandas frame
-            # carries its index into Arrow as __index_level_0__, which
-            # would print as an extra column.
-            printable = pl.from_arrow(frame.to_arrow()).select(frame.columns)
-            with pl.Config(
-                tbl_hide_dataframe_shape=True,
-                tbl_formatting="NOTHING",
-                tbl_hide_column_data_types=True,
-                float_precision=2,
-                fmt_str_lengths=100,
-                tbl_rows=-1,
-                tbl_cell_alignment="LEFT",
-                set_fmt_float="full",
-                set_tbl_width_chars=80,
-            ):
-                print(printable)
+            print(render_table(self.stat_dfs[table_type]), end="")
         else:
             if table_type == "num":
                 print("No numerical columns found")
@@ -541,7 +524,7 @@ class _Table:
             lhs = "-Categorical columns"
         elif type_ == "num":
             lhs = "-Numerical columns"
-        rhs = "-" * (80 - len(lhs))
+        rhs = "-" * (TABLE_WIDTH - len(lhs))
         print(f"{lhs}{rhs}")
 
     def show(self):

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -1,10 +1,60 @@
 from __future__ import annotations
 
+import math
 from typing import Iterable
 
 import narwhals as nw
 
 NAN = float("nan")
+
+TABLE_WIDTH = 80
+
+
+def _cell_text(value) -> str:
+    """One cell as it should print.
+
+    Missing shows as blank rather than "None" or "nan" — which of those a
+    null turns into depends on the backend, and neither belongs in a
+    summary table.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, float) and math.isnan(value):
+        return ""
+    return str(value)
+
+
+def render_table(frame: nw.DataFrame) -> str:
+    """Render a frame as the fixed-width, left-aligned table showstats prints.
+
+    This replaces printing through `pl.Config`, which is what tied the
+    output to polars. The layout it produces is the one the goldens in
+    tests/test_golden_output.py captured from that renderer: a leading
+    space, cells padded to the widest entry in their column, two spaces
+    between columns, one trailing space.
+
+    Two of polars' behaviours are deliberately not reproduced, because
+    both lose information:
+
+    - polars prints at most 8 columns and replaces the rest with "…",
+      whatever the width. Nine columns is `quantiles=[0.25, 0.5, 0.75]`,
+      so asking for a few quantiles silently dropped the Q0 column.
+    - polars wraps a cell wider than the table onto a second, unaligned
+      line. Every column is shown in full here instead; a table wider
+      than 80 characters is wider than 80 characters.
+    """
+    columns = frame.columns
+    rows = [[_cell_text(value) for value in row] for row in frame.rows()]
+    widths = [
+        max(len(name), *(len(row[i]) for row in rows)) if rows else len(name)
+        for i, name in enumerate(columns)
+    ]
+
+    def line(cells) -> str:
+        padded = "  ".join(cell.ljust(width) for cell, width in zip(cells, widths))
+        return f" {padded} "
+
+    return "\n".join([line(columns), *(line(row) for row in rows)]) + "\n"
 
 
 def _as_string(expr: nw.Expr) -> nw.Expr:

--- a/tests/_golden.py
+++ b/tests/_golden.py
@@ -31,10 +31,9 @@ CAT = (
 
 TIME = (
     "-Date and datetime columns------------------------------------------------------\n"
-    " Col (N=5)     NA%  Median      Min                  Max                 \n"
-    " date_col      0    2020-01-03  2020-01-01           2020-01-05          \n"
-    " datetime_col  0    2020-01-03  2020-01-01 12:30:15  2020-01-05 12:30:15 \n"
-    "                    12:30:15                                             \n"
+    " Col (N=5)     NA%  Median               Min                  Max                 \n"
+    " date_col      0    2020-01-03           2020-01-01           2020-01-05          \n"
+    " datetime_col  0    2020-01-03 12:30:15  2020-01-01 12:30:15  2020-01-05 12:30:15 \n"
 )
 
 ALL = (
@@ -78,10 +77,10 @@ BIG_N = (
 
 QUANTILES_FOLDED = (
     "-Numerical columns--------------------------------------------------------------\n"
-    " Col (N=5)  NA%  Avg  SD    …  Q25   Q50  Q75   Q100 \n"
-    " float_col  0    3.5  1.58  …  2.5   3.5  4.5   5.5  \n"
-    " int_col    20   2.5  1.29  …  1.75  2.5  3.25  4    \n"
-    " bool_col   0    0.6  0.55  …  0.0   1.0  1.0   true \n"
+    " Col (N=5)  NA%  Avg  SD    Q0     Q25   Q50  Q75   Q100 \n"
+    " float_col  0    3.5  1.58  1.5    2.5   3.5  4.5   5.5  \n"
+    " int_col    20   2.5  1.29  1      1.75  2.5  3.25  4    \n"
+    " bool_col   0    0.6  0.55  false  0.0   1.0  1.0   true \n"
 )
 
 QUANTILES_UNFOLDED = (

--- a/tests/test_golden_output.py
+++ b/tests/test_golden_output.py
@@ -128,12 +128,25 @@ def test_rendered_output_matches_golden(capsys, expected, df, kwargs):
     assert render(capsys, df, **kwargs) == expected
 
 
-def test_every_golden_line_fits_the_configured_width(capsys):
-    """80 chars is the configured table width, and README.md relies on it.
+def test_every_row_of_a_table_is_the_same_width(capsys):
+    """Alignment, checked as an invariant rather than only in snapshots.
 
-    Checked as an invariant as well as inside the snapshots, so a golden
-    that is updated carelessly still cannot smuggle in a wider table.
+    Every line of one table must be exactly as wide as its header row —
+    that is what "aligned columns" means, and it is the property a careless
+    golden update is most likely to break. The `-Section----` rules are
+    their own fixed 80 wide and are excluded.
+
+    Not an 80-character cap: a table only as wide as its content is the
+    point of the hand-written formatter. The old renderer wrapped anything
+    wider onto a second, unaligned line, which is what this now forbids.
     """
     for name, _expected, df, kwargs in CASES:
+        table = None
         for line in render(capsys, df, **kwargs).splitlines():
-            assert len(line) <= 80, f"{name}: {len(line)} chars: {line!r}"
+            if line.startswith("-"):
+                assert len(line) == 80, f"{name}: rule is {len(line)} chars"
+                table = None
+                continue
+            if table is None:
+                table = len(line)
+            assert len(line) == table, f"{name}: {len(line)} vs {table}: {line!r}"

--- a/tests/test_no_polars.py
+++ b/tests/test_no_polars.py
@@ -1,18 +1,15 @@
-"""The behaviour #37 is aiming at, declared up front and expected to fail.
+"""showstats works with no polars installed at all.
 
-Every test here is `@pytest.mark.rewrite` + a strict xfail: it describes
-something the narwhals migration is supposed to make true and that is not
-true yet. `xfail_strict = true` turns each one into a ratchet — the moment a
-slice makes one pass, the build fails until its markers are removed. So the
-markers cannot rot, and `make burndown` is an honest count of what is left.
+This is what #37 was for. `_table.py` imported polars at module scope and
+printed through `pl.Config`, so polars was a hard runtime dependency even
+for someone whose data was in pandas — installing showstats meant
+installing a second dataframe library to render a summary of the first.
 
-Tests are grouped by the implementation slice that should retire them, in
-the order the slices land. Nothing here is marked `integration`: CI
-deselects that marker, and hiding a rewrite test from CI would defeat the
-whole arrangement.
-
-Behaviour that already works is *not* here — it lives in the ordinary test
-files, and in `test_golden_output.py`, as the regression net.
+The check is a subprocess with an import blocker on `sys.meta_path`, not
+`monkeypatch.setitem(sys.modules, ...)`: by the time a test runs both
+showstats and polars are already imported, so an in-process block would
+only prove the cached modules still work. The finder has to be installed
+before showstats is imported at all.
 """
 
 from __future__ import annotations
@@ -22,18 +19,9 @@ import sys
 import textwrap
 
 import polars as pl
-import pytest
 
-from showstats.showstats import show_stats
 from tests import _golden
 
-pytestmark = pytest.mark.rewrite
-
-# The same data in three backends. Going through polars' own converters
-# keeps the dtypes corresponding — a hand-built pandas frame would differ in
-# ways that have nothing to do with the rewrite (int64 vs float64 for a
-# column with nulls, say), and the tests would then be measuring the
-# conversion rather than showstats.
 MIXED_PL = pl.DataFrame(
     {
         "int_col": [1, 2, 3, 4, 5],
@@ -41,13 +29,6 @@ MIXED_PL = pl.DataFrame(
         "str_col": ["a", "b", "c", "a", "b"],
     }
 )
-MIXED_PD = MIXED_PL.to_pandas()
-MIXED_PA = MIXED_PL.to_arrow()
-
-
-def render(capsys, df, **kwargs) -> str:
-    show_stats(df, **kwargs)
-    return capsys.readouterr().out
 
 
 def run_without_polars(body: str) -> subprocess.CompletedProcess:
@@ -92,23 +73,7 @@ def run_without_polars(body: str) -> subprocess.CompletedProcess:
 # Slice 4 — _Table.form_stat_df and the return type — is done. Its tests
 # now pass, so they have moved to test_make_tbl.py.
 
-# --------------------------------------------------------------------------
-# Slice 5 — _Table.show_one_table
-#
-# Printing goes through pl.Config, so there is no polars-free path to the
-# output at all: polars stops being importable-or-bust only once this
-# lands.
-#
-# Rendering no longer varies by input backend — that turned out to belong
-# to slice 1 rather than here, and its test now lives in test_backends.py.
-#
-# Which rendering wins is not open: the polars one, because README.md is
-# generated from it and is pinned in test_golden_output.py. So the last
-# test below compares against the golden, not merely against itself.
-# --------------------------------------------------------------------------
 
-
-@pytest.mark.xfail(strict=True, reason="#37: showstats._table imports polars at import")
 def test_showstats_imports_without_polars():
     result = run_without_polars("""
         import showstats
@@ -119,7 +84,6 @@ def test_showstats_imports_without_polars():
     assert "ok" in result.stdout
 
 
-@pytest.mark.xfail(strict=True, reason="#37: rendering goes through pl.Config")
 def test_show_stats_renders_without_polars():
     result = run_without_polars(f"""
         import pandas as pd
@@ -133,9 +97,6 @@ def test_show_stats_renders_without_polars():
     assert "int_col" in result.stdout
 
 
-@pytest.mark.xfail(
-    strict=True, reason="#37: form_stat_df needs polars to build a frame"
-)
 def test_make_stats_tbl_works_without_polars():
     result = run_without_polars(f"""
         import pandas as pd
@@ -151,12 +112,6 @@ def test_make_stats_tbl_works_without_polars():
     assert "ok" in result.stdout
 
 
-# --------------------------------------------------------------------------
-# The finish line — what "#37 is done" means, in one test.
-# --------------------------------------------------------------------------
-
-
-@pytest.mark.xfail(strict=True, reason="#37: polars is still a hard runtime dependency")
 def test_the_readme_table_renders_without_polars():
     """The whole point, end to end: the documented output, no polars.
 


### PR DESCRIPTION
Last implementation slice of the #37 chain. **Stacked on #81 → #80 → #79 → #77 → #76.**

**Burndown: 4 → 0.**

```
$ uv run pytest
93 passed

$ make burndown
no tests collected (93 deselected)
```

`showstats` now runs start to finish in an interpreter where importing polars raises.

## The formatter

`show_one_table` printed by handing the table to `pl.Config`. There is no narwhals renderer to hand it to instead, so the layout is written out: cells padded to the widest entry in their column, two spaces between, one leading and one trailing space. About twenty lines.

**Nine of the eleven goldens come back byte-identical.** That is the evidence the layout was reproduced rather than approximated — the whole reason PR #76 captured them before anything was touched.

## The two that changed, and why they were not reproduced

Both pinned polars *display* behaviour that loses information. Reproducing them by hand would have meant reimplementing the loss deliberately. Updated in their own commit (`3b13b66`) with the reasoning, per the plan, plus changelog entries.

**1. `QUANTILES_FOLDED` — polars was hiding a column.**

```diff
- Col (N=5)  NA%  Avg  SD    …  Q25   Q50  Q75   Q100
+ Col (N=5)  NA%  Avg  SD    Q0     Q25   Q50  Q75   Q100
```

I had assumed this was the 80-character width. It is not — polars prints **at most eight columns** and replaces the rest with `…` regardless of width, which I confirmed directly:

```python
>>> pl.DataFrame({c: ["x"] for c in "abcdefghi"})   # 9 columns, 26 chars wide
 a  b  c  d  …  f  g  h  i
```

Nine columns is `quantiles=[0.25, 0.5, 0.75]`, so asking for a few quantiles silently dropped **Q0, the minimum**. The same thing is in README.md today, where the quantiles example is missing its **Median**:

```
 Col (N=1461)  NA%  Avg    SD    …  Q0    Q10  Q90   Q100
```

**2. `TIME` — a value wider than the table wrapped onto a second, unaligned line.**

```diff
-  Col (N=5)     NA%  Median      Min                  Max
-  datetime_col  0    2020-01-03  2020-01-01 12:30:15  2020-01-05 12:30:15
-                     12:30:15
+  Col (N=5)     NA%  Median               Min                  Max
+  datetime_col  0    2020-01-03 12:30:15  2020-01-01 12:30:15  2020-01-05 12:30:15
```

Columns are sized to their contents now, so that row is 82 characters and aligned rather than 80 and broken.

`test_every_golden_line_fits_the_configured_width` went with it — an 80-character cap is precisely the rule that produced the wrapping. It is replaced by `test_every_row_of_a_table_is_the_same_width`, which checks alignment (the property a careless golden update is actually likely to break) and still holds the `-Section----` rules to exactly 80.

## `test_rewrite.py` is gone

Its four remaining tests now pass, so it has no reason to exist. They move to `tests/test_no_polars.py` as ordinary tests, keeping the subprocess import-blocker harness and the end-to-end check that the output matches the golden byte for byte with polars unimportable.

The `rewrite` marker registration and the `burndown` target are now redundant; removing them, taking polars out of `[project.dependencies]` (#42), and running `uv run nox` are the final PR.

## README

`README.md` is generated, so it is not touched here. `readme.yaml` re-renders on any push to `main` touching `src/**`, which this is — the quantiles example above will pick up its missing `Median` then.

## Verification

- [x] `uv run pytest` → **93 passed**, 0 xfailed, 0 failed
- [x] `make burndown` → zero
- [x] 9 of 11 goldens byte-identical; the 2 that changed are their own commit
- [x] pandas and pyarrow still render byte-identically to polars across all five parameter combinations
- [x] `showstats` imports, summarises and prints with polars blocked at `sys.meta_path`
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [ ] `uv run nox` — final PR

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_