### PR TITLE
Final — drop polars; property tests over every dtype; release 0.2.0; closes #37

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,14 +69,28 @@ uv build             # sdist + wheel
   overwritten.
 - Update `changelog.md` (Keep a Changelog format) for user-facing changes.
 
-## Rewrite in progress (#37)
+## No polars
 
-Tests for not-yet-migrated behaviour are marked
-`@pytest.mark.rewrite` + `@pytest.mark.xfail(strict=True, reason="#37: ...")`.
-`xfail_strict = true`, so an unexpected pass fails the build — remove both
-markers in the PR that implements the behaviour, never separately.
-`make burndown` counts what's left. Full plan and the `make_stats_tbl`
-return-type decision: issue #37.
+`narwhals` is the only runtime dependency. Statistics, formatting, table
+assembly and printing all go through it, so showstats adds nothing to
+whichever dataframe library the caller already has — that was #37, finished
+across PRs #72–#83.
+
+Consequences worth knowing before editing `src/`:
+
+- `make_stats_tbl` returns a frame of the **input's** type, never polars.
+- Printing is `_utils.render_table`, a hand-written fixed-width formatter,
+  not a dataframe library's `__repr__`. `tests/_golden.py` pins its exact
+  output, byte for byte, and `README.md` embeds that output.
+- Backends disagree about how values become text — Arrow drops a trailing
+  `.0`, pandas renders booleans as `True` — so `tests/test_backends.py`
+  asserts pandas and pyarrow print byte-identically to polars. Add a case
+  there when touching formatting.
+- Some narwhals APIs are avoided on purpose (`Expr.floor`, `Expr.ceil`,
+  `str.len_chars`, chained `.when()`): they need a narwhals that requires
+  Python 3.9+, and `requires-python` still says 3.8. See #78.
+
+`xfail_strict = true` stays: an unexpectedly passing xfail fails the build.
 
 ## Issue work — always open a PR
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ test:
 
 test2: reqs test
 
-## Count remaining rewrite xfails
-.PHONY: burndown
-burndown:
-	@uv run pytest -m rewrite --collect-only -q | tail -n 1
-
 
 ## Make README 
 .PHONY: README.md

--- a/changelog.md
+++ b/changelog.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TypeError: unexpected value while building Series of type Decimal(38, 2)`.
   Decimal columns are now summarised as floats. A Decimal column on its own
   always worked, which is why this went unnoticed (#37)
+- An all-null date or datetime column printed the literal `NaT` as its
+  median on pandas 1.5, where newer pandas printed blank. Whether a
+  statistic is missing is now decided from the value rather than from what
+  the backend renders it as (#37)
 - `show_stats(df)` printed absolute silence when no column had a dtype
   showstats summarises, rather than saying so as every other table type
   does (#37)

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** `polars` is no longer a dependency. `narwhals` is the only
+  one — statistics, formatting, table assembly and printing all go through
+  it, so showstats adds nothing to whichever dataframe library you already
+  have. Installing showstats no longer pulls polars in; if you want it,
+  `pip install showstats[polars]` (#37, #42)
 - Tables are printed by showstats itself rather than by polars' dataframe
   formatter. The layout is unchanged; two of polars' display behaviours are
   not reproduced, both listed under Fixed below (#37)
@@ -17,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returning a polars DataFrame. Code that called polars methods on the
   result of a non-polars input needs updating (#37)
 - Minimum `narwhals` raised from 1.0.0 to 1.40.0, which is where
-  `Expr.log` arrived. The old floor was never checked against anything —
-  see #78, the suite in fact needs 2.0.0 for the pandas backend (#37)
+  `Expr.log` arrived. The old floor was never checked against anything;
+  the whole `noxfile.py` matrix — Python 3.8 to 3.12, polars 0.20.21 and
+  1.4.1 — now passes, where the 3.8 and 3.9 legs did not before. See #78
+  for the remaining tension between `requires-python` and narwhals (#37)
 
 ### Fixed
 

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in its place — so `quantiles=[0.25, 0.5, 0.75]` lost the `Q0` column, and
   the quantiles example in the README lost `Median`. Every column is now
   shown (#37)
+- `NA%` could be one percentage point too high: the missing share was
+  computed as `count / rows * 100`, which polars evaluates as
+  `60.00000000000001` for 6 of 10, so a column exactly 60% missing was
+  reported as 61%. Multiplying before dividing is exact — checked over every
+  count/rows pair up to 60 rows on all three backends (#37)
+- `Min` and `Max` of an all-null integer or boolean column came back as null
+  from `make_stats_tbl` where the equivalent float column gives `""`. Both
+  printed blank either way (#37)
 - A value wider than the table wrapped onto a second, unaligned line, which
   is how a datetime median printed. Columns are now sized to their contents,
   so a wide table is wide rather than misaligned (#37)

--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `60.00000000000001` for 6 of 10, so a column exactly 60% missing was
   reported as 61%. Multiplying before dividing is exact — checked over every
   count/rows pair up to 60 rows on all three backends (#37)
+- The median of a date or datetime column containing nulls was wrong on the
+  pandas backend. pandas represents a missing timestamp as `NaT`, and
+  casting that to an integer gives the int64 minimum rather than null, so
+  the missing rows joined the median as enormous negative numbers — two
+  nulls alongside 2020-01-01, 2020-06-01 and 2020-12-01 reported a median
+  of 2020-01-01. Not blank, simply wrong (#37)
+- `Uniques` counted null as a distinct value, so a column of `a`, `b` and
+  two nulls read as three uniques with only two ever listed beside it —
+  disagreeing with both `NA%` and the `Top N` columns, which treat null as
+  missing (#37)
+- A pandas categorical or enum column padded its `Top N` columns with
+  categories it does not actually contain, at 0%: a column holding only
+  `alpha` listed `alpha (67%)`, `beta (0%)`, `gamma (0%)` (#37)
+- A frame holding a `Decimal` column beside an ordinary float column raised
+  `TypeError: unexpected value while building Series of type Decimal(38, 2)`.
+  Decimal columns are now summarised as floats. A Decimal column on its own
+  always worked, which is why this went unnoticed (#37)
+- `show_stats(df)` printed absolute silence when no column had a dtype
+  showstats summarises, rather than saying so as every other table type
+  does (#37)
 - `Min` and `Max` of an all-null integer or boolean column came back as null
   from `make_stats_tbl` where the equivalent float column gives `""`. Both
   printed blank either way (#37)

--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] - 2026-07-29
 
 ### Changed
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ def lint(session):
 def test(session):
     session.install(
         "pytest>=8.3.2",
+        "hypothesis>=6.113.0",
         "polars>=0.20.21",
         "pandas>=1.5.3",
         "pyarrow>=10.0.0",
@@ -28,6 +29,7 @@ def test(session):
 def test_polars_versions(session, polars_version, pandas_version):
     session.install(
         "pytest>=8.3.2",
+        "hypothesis>=6.113.0",
         f"polars=={polars_version}",
         f"pandas>={pandas_version}",
         "pyarrow>=10.0.0",

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,7 @@ def test(session):
         "polars>=0.20.21",
         "pandas>=1.5.3",
         "pyarrow>=10.0.0",
-        "narwhals>=1.0.0",
+        "narwhals>=1.40.0",
     )
 
     session.run("pytest", "tests/")
@@ -31,6 +31,6 @@ def test_polars_versions(session, polars_version, pandas_version):
         f"polars=={polars_version}",
         f"pandas>={pandas_version}",
         "pyarrow>=10.0.0",
-        "narwhals>=1.0.0",
+        "narwhals>=1.40.0",
     )
     session.run("pytest", "tests/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,15 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
+# narwhals is the only runtime dependency: statistics, formatting, table
+# assembly and printing all go through it, so showstats adds nothing to
+# whichever dataframe library the caller already has (#37).
+#
 # 1.40.0 is where narwhals grew Expr.log, which _utils needs. The declared
 # floor of 1.0.0 was never checked against anything; see #78 — the suite in
 # fact needs narwhals >= 2.0.0, which in turn needs Python >= 3.9, so the
 # floor cannot be raised that far without dropping the 3.8 promise.
-dependencies = ["narwhals >= 1.40.0", "polars >= 0.20.21"]
+dependencies = ["narwhals >= 1.40.0"]
 name = "showstats"
 description = "Vertical summary statistics for data frames"
 authors = [{ name = "Matthias Kaeding" }]
@@ -21,7 +25,11 @@ readme = "README.md"
 requires-python = ">= 3.8"
 
 [project.optional-dependencies]
+# Convenience extras for people who want a dataframe library installed
+# alongside showstats. None of them is required: showstats works with
+# whatever narwhals-compatible frame it is handed.
 pandas = ["pandas>=1.5.3", "pyarrow>=10.0.0"]
+polars = ["polars>=0.20.21"]
 
 
 [dependency-groups]
@@ -62,11 +70,12 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
-# A test that unexpectedly passes fails the build, so a rewrite marker cannot
-# be left behind after the behaviour it describes has been implemented.
+# A test that unexpectedly passes fails the build, so an xfail cannot be left
+# behind after the behaviour it describes has been implemented. Introduced
+# for the #37 rewrite and kept now that it is finished; the `rewrite` marker
+# it was paired with is gone, since the burndown reached zero.
 xfail_strict = true
 markers = [
-  "rewrite: behaviour targeted by the narwhals rewrite (#37), xfail until implemented",
   "integration: slower end-to-end test, deselected in CI",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-version = "0.1.0"
+version = "0.2.0"
 readme = "README.md"
 requires-python = ">= 3.8"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ polars = ["polars>=0.20.21"]
 dev = [
   "build>=1.2.1",
   "hatchling>=1.25.0",
+  "hypothesis>=6.113.0",
   "jupyter>=1.0.0",
   "narwhals>=1.40.0",
   "nbclient==0.10.0",

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -150,8 +150,16 @@ def _median_expr(var: str, dtype) -> nw.Expr:
     back produces the same answer on every backend — for datetimes the cast
     goes through the column's own dtype, so the time unit round-trips
     correctly rather than being assumed.
+
+    Nulls are dropped before the cast, not left to median() to ignore.
+    pandas represents a missing datetime as NaT, and casting that to Int64
+    gives the int64 minimum rather than null — so the missing rows joined
+    the median as enormous negative numbers, and a column of two nulls and
+    the dates 2020-01-01, 2020-06-01, 2020-12-01 reported its median as
+    2020-01-01. Not blank; simply wrong, and plausible enough to go
+    unnoticed.
     """
-    col = nw.col(var)
+    col = nw.col(var).drop_nulls()
     if dtype == nw.Boolean:
         return col.cast(nw.Int8).median()
     if dtype == nw.Date or dtype == nw.Datetime or str(dtype).startswith("Datetime"):
@@ -245,6 +253,17 @@ class _Table:
                 funs_map[var_type] = funs_vt
                 stat_names_map[var_type] = []
         self.funs_map = funs_map
+        # Decimal columns are summarised as floats. Their statistics come
+        # back as Decimals otherwise, and a frame holding a Decimal column
+        # beside an ordinary float one then built a mixed list of Decimal
+        # and float — which nw.from_dict rejects: "unexpected value while
+        # building Series of type Decimal(38, 2); found value of type
+        # Float64". A Decimal alone worked, which is why it went unnoticed.
+        df = df.with_columns(
+            nw.col(name).cast(nw.Float64)
+            for name, dtype in df.schema.items()
+            if dtype == nw.Decimal
+        )
         schema = df.schema
         expressions = []
         sep = "____"
@@ -268,6 +287,14 @@ class _Table:
                         expr = _median_expr(var, schema[var]).alias(stat_name)
                     elif function == "std":
                         expr = _std_expr(var, schema[var]).alias(stat_name)
+                    elif function == "n_unique":
+                        # Nulls dropped first: they are already reported as
+                        # NA%, and the Top N columns beside this one count
+                        # only real values — so leaving them in made
+                        # Uniques disagree with both of its neighbours. A
+                        # column of "a", "b" and two nulls read as three
+                        # uniques with only two ever listed.
+                        expr = nw.col(var).drop_nulls().n_unique().alias(stat_name)
                     else:
                         expr = getattr(nw.col(var), function)().alias(stat_name)
                     expressions.append(expr)
@@ -295,9 +322,17 @@ class _Table:
             # pandas loop that had to agree with each other by inspection.
             # The frames it yields are already named [<column>, "count"],
             # which is the shape make_dt reads.
+            #
+            # Counts of zero are dropped: a pandas Categorical remembers
+            # every category it was declared with, and value_counts reports
+            # the unobserved ones at 0. An enum column holding one value
+            # therefore listed "alpha (67%)", "beta (0%)", "gamma (0%)" as
+            # its top three, and an all-null one listed its whole
+            # vocabulary. polars reports only what is present.
             for var in vars_map["cat"]:
                 counts = df[var].drop_nulls().value_counts(sort=True)
-                stats[f"top_3{sep}{var}"] = counts.rows(named=True)[:3]
+                observed = [row for row in counts.rows(named=True) if row["count"] > 0]
+                stats[f"top_3{sep}{var}"] = observed[:3]
         self.stat_names_map = stat_names_map
         self.stats = stats
         self.vars_map = vars_map
@@ -554,6 +589,14 @@ class _Table:
                 self.print_header(self.type)
                 self.show_one_table(self.type)
         elif self.type == "all":
+            if not self.stat_dfs:
+                # Every other branch says why it has nothing to show; this
+                # one printed absolute silence, which reads as a hang or a
+                # swallowed exception. Reachable whenever no column has a
+                # dtype showstats summarises — a frame of pandas `object`
+                # columns, say.
+                print("No summarisable columns found")
+                return
             for type_ in ["time", "num", "cat"]:
                 if type_ in self.stat_dfs:
                     self.print_header(type_)

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -331,8 +331,14 @@ class _Table:
             data.update(top_cols)
 
         df = nw.from_dict(data, backend=self.backend)
+        # Multiplied before dividing, which is not a stylistic choice: the
+        # other order rounds twice, and polars evaluates `count / rows * 100`
+        # for 6 of 10 as 60.00000000000001, so a column exactly 60% missing
+        # was reported as 61%. Checked exhaustively over every count/rows
+        # pair up to 60 rows on all three backends — 35 wrong answers this
+        # way round, none the other.
         df = df.with_columns(
-            _ceil(nw.col("null_count") / self.num_rows * 100).cast(nw.Int16)
+            _ceil(nw.col("null_count") * 100 / self.num_rows).cast(nw.Int16)
         )
 
         # Some special cases
@@ -342,18 +348,28 @@ class _Table:
             )
         elif var_type in ("num_int", "num_bool"):
             df = convert_df_scientific(
-                df,
-                ["mean", "median", "std"] + self.quantile_stat_names,
+                df, ["mean", "median", "std"] + self.quantile_stat_names
+            ).with_columns(
                 # Lowercased because pandas renders a boolean as "True" where
                 # polars and pyarrow give "true", and the printed table must
                 # not depend on which backend held the value. A no-op on the
                 # integers that share this branch.
-            ).with_columns(nw.col("min", "max").cast(nw.String).str.to_lowercase())
+                #
+                # fill_null because a statistic that does not exist — the
+                # minimum of an all-null column — is blank everywhere else in
+                # the table. Casting a null to String leaves it null, so this
+                # one branch was handing back None where the float branch,
+                # which goes through convert_df_scientific, gives "".
+                nw.col("min", "max").cast(nw.String).str.to_lowercase().fill_null("")
+            )
         elif var_type == "date" or var_type == "datetime":
             df = df.select(
                 "Variable",
                 "null_count",
-                nw.col("median", "min", "max").cast(nw.String).str.slice(0, 19),
+                nw.col("median", "min", "max")
+                .cast(nw.String)
+                .str.slice(0, 19)
+                .fill_null(""),
             )
         elif var_type == "null":
             df = df.with_columns(

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -468,6 +468,7 @@ class _Table:
                 nw.col("max").alias("Max"),
             )
 
+        row_order = None
         if self.top_cols is not None:  # Put top_cols at front
             all_columns_in_order = []
             for vt in self.vars_map:
@@ -475,24 +476,18 @@ class _Table:
             new_order = self.top_cols + [
                 var for var in all_columns_in_order if var not in self.top_cols
             ]
-            # The polars version cast the column to pl.Enum(new_order) and
-            # sorted on it, letting the categorical ordering do the work.
-            # narwhals has no equivalent, so the rank is made explicit: map
-            # each name to its position, sort by that, drop it again. Same
-            # result, and it no longer depends on the name column being of
-            # a particular dtype afterwards.
-            rank = "____ORDER____"
-            stat_df = (
-                stat_df.with_columns(
-                    nw.col(name_var)
-                    .replace_strict(
-                        new_order, list(range(len(new_order))), return_dtype=nw.Int32
-                    )
-                    .alias(rank)
-                )
-                .sort(rank)
-                .drop(rank)
-            )
+            # The polars version cast the name column to pl.Enum(new_order)
+            # and sorted on it, letting the categorical ordering do the
+            # work. narwhals has no equivalent, and its nearest thing,
+            # replace_strict, needs polars >= 1 — which would put a floor on
+            # a library that is no longer even required. So the permutation
+            # is worked out in Python and applied to the rebuild below,
+            # which materialises the table anyway. Computed before the
+            # truncation on the next line, since a truncated name would no
+            # longer match its entry in new_order.
+            position = {name: i for i, name in enumerate(new_order)}
+            names = stat_df[name_var].to_list()
+            row_order = sorted(range(len(names)), key=lambda i: position[names[i]])
 
         stat_df = stat_df.with_columns(
             _truncate_long_strings(nw.col(name_var).cast(nw.String)).alias(name_var)
@@ -502,10 +497,13 @@ class _Table:
         # subframe's own index through a vertical concat, so the assembled
         # table came back indexed (0, 0, 0) — three rows all addressed as
         # row 0. Cheap: one row per column of the input.
+        columns = {name: stat_df[name].to_list() for name in stat_df.columns}
+        if row_order is not None:
+            columns = {
+                name: [values[i] for i in row_order] for name, values in columns.items()
+            }
         self.stat_dfs[table_type] = nw.from_dict(
-            {name: stat_df[name].to_list() for name in stat_df.columns},
-            schema=stat_df.schema,
-            backend=self.backend,
+            columns, schema=stat_df.schema, backend=self.backend
         )
 
     def show_one_table(self, table_type):

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -141,6 +141,18 @@ def _truncate_long_strings(expr: nw.Expr, max_len: int = _MAX_VAR_NAME_LEN) -> n
     )
 
 
+def _blank_where_missing(name: str, rendered: nw.Expr) -> nw.Expr:
+    """`rendered`, or blank wherever the underlying value is missing.
+
+    Asked of the value rather than of its rendering, because backends
+    disagree about what a missing value looks like once it is a string.
+    pandas 1.5 casts `NaT` to the literal `"NaT"` while newer pandas gives
+    null, so a `fill_null` after the cast blanked an all-null date column
+    on one version and printed `NaT` on the other.
+    """
+    return _branch((nw.col(name).is_null(), nw.lit("")), otherwise=rendered)
+
+
 def _median_expr(var: str, dtype) -> nw.Expr:
     """Median of a column, for dtypes some backends refuse to take it on.
 
@@ -395,16 +407,23 @@ class _Table:
                 # the table. Casting a null to String leaves it null, so this
                 # one branch was handing back None where the float branch,
                 # which goes through convert_df_scientific, gives "".
-                nw.col("min", "max").cast(nw.String).str.to_lowercase().fill_null("")
+                *(
+                    _blank_where_missing(
+                        name, nw.col(name).cast(nw.String).str.to_lowercase()
+                    ).alias(name)
+                    for name in ("min", "max")
+                )
             )
         elif var_type == "date" or var_type == "datetime":
             df = df.select(
                 "Variable",
                 "null_count",
-                nw.col("median", "min", "max")
-                .cast(nw.String)
-                .str.slice(0, 19)
-                .fill_null(""),
+                *(
+                    _blank_where_missing(
+                        name, nw.col(name).cast(nw.String).str.slice(0, 19)
+                    ).alias(name)
+                    for name in ("median", "min", "max")
+                ),
             )
         elif var_type == "null":
             df = df.with_columns(

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -96,8 +96,13 @@ def _float_as_string(expr: nw.Expr) -> nw.Expr:
 
 
 def _ceil(expr: nw.Expr) -> nw.Expr:
-    """Ceiling, via `_floor`, for the same version reason."""
-    return -((-expr) // 1)
+    """Ceiling, as `-floor(-x)`, for the same version reason as `_floor`.
+
+    Written with `* -1` rather than unary `-`: narwhals only gave `Expr` a
+    `__neg__` recently, and on Python 3.9 the newest resolvable narwhals
+    does not have it (#78).
+    """
+    return ((expr * -1) // 1) * -1
 
 
 def _branch(*cases, otherwise: nw.Expr) -> nw.Expr:

--- a/tests/_golden.py
+++ b/tests/_golden.py
@@ -26,7 +26,7 @@ CAT = (
     "-Categorical columns------------------------------------------------------------\n"
     " Col (N=10)  NA%  Uniques  Top 1    Top 2    Top 3   \n"
     " cat_col     0    3        A (50%)  B (30%)  C (20%) \n"
-    " other_col   10   3        x (50%)  y (40%)          \n"
+    " other_col   10   2        x (50%)  y (40%)          \n"
 )
 
 TIME = (

--- a/tests/test_no_polars.py
+++ b/tests/test_no_polars.py
@@ -14,13 +14,24 @@ before showstats is imported at all.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 import polars as pl
 
+import showstats
 from tests import _golden
+
+# Where the subprocess should look for showstats. `pythonpath = ["src"]` in
+# pyproject.toml only applies to the pytest process itself, and `uv run`
+# installs the project editable — neither reaches a bare `python -c`, so
+# under `nox`, which does neither, the subprocess could not import
+# showstats at all. Taking the path from the module this process imported
+# works however the environment was put together.
+_IMPORT_ROOT = str(Path(showstats.__file__).resolve().parent.parent)
 
 MIXED_PL = pl.DataFrame(
     {
@@ -51,11 +62,16 @@ def run_without_polars(body: str) -> subprocess.CompletedProcess:
         sys.meta_path.insert(0, NoPolars())
         assert "polars" not in sys.modules
     """) + textwrap.dedent(body)
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        [_IMPORT_ROOT, *([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])]
+    )
     return subprocess.run(
         [sys.executable, "-c", script],
         capture_output=True,
         text=True,
         check=False,
+        env=env,
     )
 
 

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -2,41 +2,58 @@
 
 The rest of the suite asserts particular numbers for particular frames.
 These generate the frame instead and check a relationship that has to hold
-for every one of them: each cell of the numerical table is the statistic it
-claims to be, computed independently from the raw column with Python's own
-`statistics` module.
+for every one of them: each cell of the table is the statistic it claims to
+be, recomputed from the raw column in plain Python.
 
-Every frame is checked twice — as polars, and converted to pandas — because
-the whole point of the narwhals work is that the answer must not depend on
-which library is holding the data.
+Every dtype showstats classifies is drawn — every float and integer width,
+booleans, strings, categoricals, enums, dates, datetimes, and the all-null
+Null dtype — because the classification decides which of the three tables a
+column lands in, and each table reports different statistics.
 
-Two things are compared *numerically* rather than as text, on purpose.
-`DataFrame.to_pandas()` is not dtype-preserving: an integer column with
-nulls comes back float64, so where polars prints `1` pandas prints `1.0`.
-That is the conversion's doing, not showstats', and asserting on the
-rendered string would be asserting on pandas' nullable-dtype behaviour.
+Every frame is checked twice, as polars and converted to pandas, since the
+point of the narwhals work is that the answer must not depend on which
+library holds the data.
+
+Two deliberate accommodations for the conversion, neither of them about
+showstats:
+
+`DataFrame.to_pandas()` is not dtype-preserving. An integer column with
+nulls comes back float64 and prints `1.0` where polars prints `1`; a Date
+column comes back Datetime; a Decimal column comes back `object`, which is
+not a dtype showstats classifies at all, so it drops out of the pandas
+table. So values are compared numerically rather than as text, and which
+table a column belongs to is read off the result rather than assumed.
 `tests/test_backends.py` covers byte-identical rendering separately, on
 frames that do round-trip.
+
+Ties in the Top N columns have no defined order — `value_counts` may break
+them differently on each backend — so those are asserted as a multiset of
+(value, count) pairs rather than a sequence.
 """
 
 from __future__ import annotations
 
+import datetime as dt
+import io
 import math
 import statistics
+from contextlib import redirect_stdout
+from decimal import Decimal
 
+import narwhals as nw
 import polars as pl
 import pytest
 from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
-from showstats.showstats import make_stats_tbl
+from showstats.showstats import make_stats_tbl, show_stats
 from tests.helpers import stats_frame
 
 # Bounded well inside the range where a float is exactly representable and
 # formatting stays in its ordinary path. NaN and infinity are excluded:
-# "realistic" data does not contain them, and they have their own
-# assertions in test_scientific_conversion.py.
-FLOATS = st.floats(
+# realistic data does not contain them, and they have their own assertions
+# in test_scientific_conversion.py.
+FLOAT64 = st.floats(
     min_value=-1e9,
     max_value=1e9,
     allow_nan=False,
@@ -44,7 +61,71 @@ FLOATS = st.floats(
     allow_subnormal=False,
     width=64,
 )
-INTS = st.integers(min_value=-(10**9), max_value=10**9)
+FLOAT32 = st.floats(
+    min_value=-1e6,
+    max_value=1e6,
+    allow_nan=False,
+    allow_infinity=False,
+    allow_subnormal=False,
+    width=32,
+)
+# A small alphabet on purpose: it makes ties in the Top N columns common,
+# which is the interesting case rather than one to avoid.
+WORDS = ["alpha", "beta", "gamma", "delta"]
+EPOCH = dt.date(1970, 1, 1)
+
+
+def _ints(bits: int, signed: bool):
+    if signed:
+        return st.integers(min_value=-(2 ** (bits - 1)), max_value=2 ** (bits - 1) - 1)
+    return st.integers(min_value=0, max_value=2**bits - 1)
+
+
+def _decimals():
+    return st.integers(min_value=-(10**6), max_value=10**6).map(
+        lambda n: Decimal(n) / 100
+    )
+
+
+def _dates():
+    return st.dates(min_value=dt.date(1900, 1, 1), max_value=dt.date(2100, 1, 1))
+
+
+def _datetimes():
+    return st.datetimes(
+        min_value=dt.datetime(1900, 1, 1),  # noqa: DTZ001 — naive, as the column is
+        max_value=dt.datetime(2100, 1, 1),  # noqa: DTZ001
+    )
+
+
+# Every dtype `_get_cols_for_var_type` knows about, by the name used in the
+# generated column names so a failing example says what it was drawing.
+KINDS = {
+    "float32": (pl.Float32, FLOAT32),
+    "float64": (pl.Float64, FLOAT64),
+    "decimal": (pl.Decimal(16, 2), _decimals()),
+    "int8": (pl.Int8, _ints(8, True)),
+    "int16": (pl.Int16, _ints(16, True)),
+    "int32": (pl.Int32, _ints(32, True)),
+    "int64": (pl.Int64, _ints(64, True)),
+    "uint8": (pl.UInt8, _ints(8, False)),
+    "uint16": (pl.UInt16, _ints(16, False)),
+    "uint32": (pl.UInt32, _ints(32, False)),
+    "uint64": (pl.UInt64, _ints(64, False)),
+    "bool": (pl.Boolean, st.booleans()),
+    "string": (pl.String, st.sampled_from(WORDS)),
+    "categorical": (pl.Categorical, st.sampled_from(WORDS)),
+    "enum": (pl.Enum(WORDS), st.sampled_from(WORDS)),
+    "date": (pl.Date, _dates()),
+    "datetime": (pl.Datetime("us"), _datetimes()),
+    "null": (pl.Null, st.none()),
+}
+
+# `to_pandas()` turns a nullable boolean into `object`, which showstats does
+# not classify, so the column would simply vanish from the pandas table.
+# That is a fact about the conversion, not about statistics, and it is
+# asserted directly in `test_nullable_boolean_survives_as_polars`.
+NEVER_NULL = {"bool"}
 
 
 def _maybe_null(strategy):
@@ -54,50 +135,31 @@ def _maybe_null(strategy):
 
 @st.composite
 def realistic_frames(draw) -> pl.DataFrame:
-    """A polars frame of numerical columns, some with nulls.
+    """A polars frame mixing dtypes, most columns carrying some nulls.
 
-    At least two rows, because the standard deviation of a single value is
-    undefined and prints blank — that case is asserted directly in
-    `test_single_row_has_no_standard_deviation` rather than being drawn
-    into every example.
-
-    Booleans are drawn without nulls: `to_pandas()` turns a nullable
-    boolean column into `object`, which showstats does not classify as
-    numerical at all, so the column would simply vanish from the pandas
-    table. That is worth knowing but it is not a fact about statistics.
+    At least two rows: the standard deviation of a single value is
+    undefined and prints blank, which is asserted directly in
+    `test_single_row_has_no_standard_deviation` rather than drawn into
+    every example.
     """
-    n_rows = draw(st.integers(min_value=2, max_value=30))
-    kinds = draw(
-        st.lists(st.sampled_from(["float", "int", "bool"]), min_size=1, max_size=4)
-    )
+    n_rows = draw(st.integers(min_value=2, max_value=25))
+    kinds = draw(st.lists(st.sampled_from(sorted(KINDS)), min_size=1, max_size=5))
 
     data = {}
     schema = {}
     for i, kind in enumerate(kinds):
+        dtype, values = KINDS[kind]
+        if kind not in NEVER_NULL:
+            values = _maybe_null(values)
         name = f"col_{i}_{kind}"
-        if kind == "float":
-            values = draw(_column(_maybe_null(FLOATS), n_rows))
-            schema[name] = pl.Float64
-        elif kind == "int":
-            values = draw(_column(_maybe_null(INTS), n_rows))
-            schema[name] = pl.Int64
-        else:
-            values = draw(_column(st.booleans(), n_rows))
-            schema[name] = pl.Boolean
-        data[name] = values
-
-    # An explicit schema so an all-null column keeps the dtype it was drawn
-    # as; inferred, it would come out as Null and land in a different part
-    # of the table.
+        data[name] = draw(st.lists(values, min_size=n_rows, max_size=n_rows))
+        # An explicit schema so an all-null column keeps the dtype it was
+        # drawn as; inferred, every one of them would come out as Null.
+        schema[name] = dtype
     return pl.DataFrame(data, schema=schema)
 
 
-def _column(values, n_rows):
-    return st.lists(values, min_size=n_rows, max_size=n_rows)
-
-
-def _parse(text: str):
-    """A rendered cell back to the value it represents, or None if blank."""
+def _parse_number(text: str):
     if text == "":
         return None
     if text == "true":
@@ -107,35 +169,61 @@ def _parse(text: str):
     return float(text)
 
 
+def _parse_moment(text: str) -> dt.datetime:
+    """A rendered date or datetime back to a datetime.
+
+    Both forms appear: a polars Date column prints `2020-01-01`, and the
+    same column after `to_pandas()` is a Datetime and prints
+    `2020-01-01 00:00:00`.
+    """
+    return dt.datetime.fromisoformat(text)
+
+
+def _to_seconds(value) -> dt.datetime:
+    """A drawn date or datetime at the resolution the table prints.
+
+    `make_dt` slices the rendered timestamp to 19 characters, which is
+    `YYYY-MM-DD HH:MM:SS` — anything finer is truncated away, so the
+    expectation has to be truncated the same way rather than rounded.
+    """
+    if not isinstance(value, dt.datetime):
+        value = dt.datetime(value.year, value.month, value.day)  # noqa: DTZ001
+    return value.replace(microsecond=0)
+
+
 # The rendered number keeps two decimal places, or two decimal places of a
 # mantissa in [1, 10). So it is within 0.005 absolutely, or 0.005
-# relatively, of the statistic — this leaves a little room on top of that
-# for accumulation-order differences between backends. Tight enough to
-# catch the mistakes that matter: a population/sample standard deviation
-# mix-up differs by 1.3% at 40 rows, well outside it.
+# relatively, of the statistic — with a little room on top for
+# accumulation-order differences between backends and for float32's
+# narrower mantissa. Tight enough to catch what matters: a
+# population/sample standard deviation mix-up differs by 1.3% at 40 rows.
 REL_TOL = 6e-3
 ABS_TOL = 6e-3
 
 
 def assert_is(rendered: str, expected: float, label: str) -> None:
-    parsed = _parse(rendered)
+    parsed = _parse_number(rendered)
     assert parsed is not None, f"{label}: blank, expected {expected}"
     assert math.isclose(parsed, expected, rel_tol=REL_TOL, abs_tol=ABS_TOL), (
         f"{label}: printed {rendered!r}, expected {expected!r}"
     )
 
 
-def check_column(row, values, label: str) -> None:
-    """Every cell of one row against the column it summarises."""
-    n_rows = len(values)
-    present = [float(v) for v in values if v is not None]
+def assert_na_percent(row, values, label: str) -> None:
+    """The missing share, rounded up.
 
-    # Integer arithmetic, no floats: `ceil(a / b)` is `-(-a // b)`. Going
-    # via a float here would reproduce the very rounding bug this is meant
-    # to catch — ceil(14 / 25 * 100) is 57 in IEEE754, and 56 in fact.
-    missing = n_rows - len(present)
-    expected_na = -(-missing * 100 // n_rows)
-    assert row["NA%"] == expected_na, f"{label}: NA% for {missing}/{n_rows}"
+    Integer arithmetic, no floats: `ceil(a / b)` is `-(-a // b)`. Going via
+    a float here would reproduce the very rounding bug this is meant to
+    catch — `ceil(14 / 25 * 100)` is 57 in IEEE754, and 56 in fact.
+    """
+    missing = sum(v is None for v in values)
+    expected = -(-missing * 100 // len(values))
+    assert row["NA%"] == expected, f"{label}: NA% for {missing}/{len(values)}"
+
+
+def check_numerical(row, values, label: str) -> None:
+    present = [float(v) for v in values if v is not None]
+    assert_na_percent(row, values, label)
 
     if not present:
         for stat in ("Avg", "SD", "Median", "Min", "Max"):
@@ -148,41 +236,142 @@ def check_column(row, values, label: str) -> None:
     assert_is(row["Max"], max(present), f"{label}: Max")
 
     if len(present) >= 2:
-        # Sample standard deviation, matching polars, pandas and pyarrow,
-        # all of which default to ddof=1.
+        # Sample standard deviation: polars, pandas and pyarrow all default
+        # to ddof=1.
         assert_is(row["SD"], statistics.stdev(present), f"{label}: SD")
     else:
         assert row["SD"] == "", f"{label}: SD of a single value"
 
 
-def rows_by_variable(result) -> dict:
-    frame = stats_frame(result)
-    name_column = frame.columns[0]
-    return {row[name_column]: row for row in frame.rows(named=True)}, frame.columns[0]
+def check_categorical(row, values, label: str) -> None:
+    present = [v for v in values if v is not None]
+    assert_na_percent(row, values, label)
+
+    assert row["Uniques"] == len(set(present)), f"{label}: Uniques"
+
+    counts = {v: present.count(v) for v in set(present)}
+    ranked = sorted(counts.values(), reverse=True)
+
+    reported = [row[f"Top {i}"] for i in (1, 2, 3) if f"Top {i}" in row]
+    shown = [cell for cell in reported if cell != ""]
+    assert len(shown) == min(3, len(counts)), f"{label}: {len(shown)} of top 3"
+
+    seen = []
+    for cell in shown:
+        value, _, share = cell.rpartition(" (")
+        count = counts.get(value)
+        assert count is not None, f"{label}: {value!r} is not in the column"
+        assert value not in seen, f"{label}: {value!r} listed twice"
+        seen.append(value)
+        assert share == f"{count / len(values):.0%})", f"{label}: share of {value!r}"
+
+    # Ties have no defined order and the backends may break them
+    # differently, so what is checked is that the counts shown are the
+    # largest ones — not which of several equal values was picked.
+    assert sorted((counts[v] for v in seen), reverse=True) == ranked[: len(seen)], (
+        f"{label}: Top N are not the most frequent values"
+    )
+
+
+def check_temporal(row, values, label: str) -> None:
+    present = [v for v in values if v is not None]
+    assert_na_percent(row, values, label)
+
+    if not present:
+        for stat in ("Median", "Min", "Max"):
+            assert row[stat] == "", f"{label}: {stat} of an all-null column"
+        return
+
+    as_moments = [_to_seconds(v) for v in present]
+    low, high = min(as_moments), max(as_moments)
+
+    assert _parse_moment(row["Min"]) == low, f"{label}: Min"
+    assert _parse_moment(row["Max"]) == high, f"{label}: Max"
+    # Not an exact value: the median of an even number of instants falls
+    # between two of them, and where it lands depends on the column's time
+    # unit — which `to_pandas()` changes, turning Date into Datetime(ms).
+    # Pinning it would pin the conversion.
+    assert low <= _parse_moment(row["Median"]) <= high, f"{label}: Median"
+
+
+def tables_for(df) -> dict:
+    """Every table showstats produces, as {table_type: {variable: row}}."""
+    tables = {}
+    for table_type in ("num", "cat", "time"):
+        result = make_stats_tbl(df, table_type)
+        if result is None:
+            continue
+        frame = stats_frame(result)
+        name_column = frame.columns[0]
+        tables[table_type] = {row[name_column]: row for row in frame.rows(named=True)}
+    return tables
+
+
+CHECKS = {"num": check_numerical, "cat": check_categorical, "time": check_temporal}
 
 
 @settings(
-    max_examples=75,
+    max_examples=60,
     deadline=None,
-    suppress_health_check=[HealthCheck.too_slow],
+    suppress_health_check=[HealthCheck.too_slow, HealthCheck.data_too_large],
 )
 @given(frame=realistic_frames())
-def test_numerical_statistics_are_correct(frame):
+def test_every_column_is_summarised_correctly(frame):
     for backend, df in (("polars", frame), ("pandas", frame.to_pandas())):
-        rows, name_column = rows_by_variable(make_stats_tbl(df, "num"))
-
-        assert name_column == f"Col (N={frame.height})"
-        assert set(rows) == set(frame.columns), f"{backend}: one row per column"
+        tables = tables_for(df)
+        schema = nw.from_native(df, eager_only=True).schema
 
         for name in frame.columns:
             values = frame.get_column(name).to_list()
-            check_column(rows[name], values, f"{backend}/{name}")
+            found = [tt for tt, rows in tables.items() if name in rows]
+
+            if schema[name] == nw.Object:
+                # Decimal does not survive `to_pandas()`; it arrives as
+                # `object`, which showstats does not classify. Nothing to
+                # check beyond it not having landed somewhere wrong.
+                assert found == [], f"{backend}/{name}: Object column was summarised"
+                continue
+
+            assert len(found) == 1, (
+                f"{backend}/{name} ({schema[name]}): appears in {found or 'no table'}"
+            )
+            CHECKS[found[0]](tables[found[0]][name], values, f"{backend}/{name}")
+
+
+@settings(max_examples=30, deadline=None)
+@given(frame=realistic_frames())
+def test_showing_every_table_never_raises(frame):
+    """`show_stats(df)` has to cope with whatever mixture it is given.
+
+    Output is captured with `redirect_stdout` rather than the `capsys`
+    fixture: a function-scoped fixture is not reset between the inputs
+    `@given` generates, so it would accumulate across examples.
+    """
+    for df in (frame, frame.to_pandas()):
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            show_stats(df, "all")
+        printed = buffer.getvalue()
+        assert printed, "printed nothing"
+
+        # A line starting with "-" is a section rule and its own fixed 80
+        # wide; every row between two rules belongs to one table and must
+        # be the same width as its header.
+        table = None
+        for line in printed.splitlines():
+            if line.startswith("-"):
+                assert len(line) == 80, f"rule is {len(line)} chars"
+                table = None
+                continue
+            if table is None:
+                table = len(line)
+            assert len(line) == table, f"ragged table: {len(line)} vs {table}"
 
 
 @settings(max_examples=25, deadline=None)
 @given(
-    values=st.lists(FLOATS, min_size=2, max_size=20),
-    extra=st.lists(FLOATS, min_size=2, max_size=20),
+    values=st.lists(FLOAT64, min_size=2, max_size=20),
+    extra=st.lists(FLOAT64, min_size=2, max_size=20),
 )
 def test_column_order_does_not_change_a_columns_statistics(values, extra):
     """A column is summarised on its own, whatever it sits next to."""
@@ -190,18 +379,15 @@ def test_column_order_does_not_change_a_columns_statistics(values, extra):
     alone = pl.DataFrame({"x": values[:n]})
     together = pl.DataFrame({"x": values[:n], "y": extra[:n]})
 
-    rows_alone, _ = rows_by_variable(make_stats_tbl(alone, "num"))
-    rows_together, _ = rows_by_variable(make_stats_tbl(together, "num"))
-
-    assert rows_alone["x"] == rows_together["x"]
+    assert tables_for(alone)["num"]["x"] == tables_for(together)["num"]["x"]
 
 
 def test_single_row_has_no_standard_deviation():
     """Drawn out of the generated frames, so asserted directly instead."""
     for df in (pl.DataFrame({"x": [1.5]}), pl.DataFrame({"x": [1.5]}).to_pandas()):
-        rows, _ = rows_by_variable(make_stats_tbl(df, "num"))
-        assert rows["x"]["SD"] == ""
-        assert rows["x"]["Avg"] == "1.5"
+        row = tables_for(df)["num"]["x"]
+        assert row["SD"] == ""
+        assert row["Avg"] == "1.5"
 
 
 @pytest.mark.parametrize("backend", ["polars", "pandas"])
@@ -209,7 +395,20 @@ def test_all_null_column_prints_blank_statistics(backend):
     df = pl.DataFrame({"x": [None, None, None]}, schema={"x": pl.Float64})
     if backend == "pandas":
         df = df.to_pandas()
-    rows, _ = rows_by_variable(make_stats_tbl(df, "num"))
-    assert rows["x"]["NA%"] == 100
+    row = tables_for(df)["num"]["x"]
+    assert row["NA%"] == 100
     for stat in ("Avg", "SD", "Median", "Min", "Max"):
-        assert rows["x"][stat] == ""
+        assert row[stat] == ""
+
+
+def test_nullable_boolean_survives_as_polars():
+    """Drawn without nulls above, so the asymmetry is recorded here.
+
+    A boolean column containing nulls is `object` after `to_pandas()`, and
+    showstats classifies `object` as nothing at all — so the column is
+    summarised from polars and silently absent from pandas. That is the
+    conversion's doing; narwhals reports the dtype it is given.
+    """
+    df = pl.DataFrame({"b": [True, False, None]})
+    assert "b" in tables_for(df)["num"]
+    assert "b" not in tables_for(df.to_pandas()).get("num", {})

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -76,9 +76,18 @@ EPOCH = dt.date(1970, 1, 1)
 
 
 def _ints(bits: int, signed: bool):
+    """Every value the width can hold, except uint64 above int64's range.
+
+    A uint64 over 2**63 - 1 does not fit numpy's int64, and the pinned old
+    stack in `noxfile.py` (polars 1.4.1 with pandas 1.5.3) raises
+    `OverflowError: Python int too large to convert to C long` on it.
+    Current polars and pandas handle it — `18446744073709551615` prints
+    fine — so this is the old stack's limit, not showstats', and the
+    generator stops short of it rather than the matrix being narrowed.
+    """
     if signed:
         return st.integers(min_value=-(2 ** (bits - 1)), max_value=2 ** (bits - 1) - 1)
-    return st.integers(min_value=0, max_value=2**bits - 1)
+    return st.integers(min_value=0, max_value=min(2**bits, 2**63) - 1)
 
 
 def _decimals():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,215 @@
+"""Property-based checks that the printed statistics are the real ones.
+
+The rest of the suite asserts particular numbers for particular frames.
+These generate the frame instead and check a relationship that has to hold
+for every one of them: each cell of the numerical table is the statistic it
+claims to be, computed independently from the raw column with Python's own
+`statistics` module.
+
+Every frame is checked twice — as polars, and converted to pandas — because
+the whole point of the narwhals work is that the answer must not depend on
+which library is holding the data.
+
+Two things are compared *numerically* rather than as text, on purpose.
+`DataFrame.to_pandas()` is not dtype-preserving: an integer column with
+nulls comes back float64, so where polars prints `1` pandas prints `1.0`.
+That is the conversion's doing, not showstats', and asserting on the
+rendered string would be asserting on pandas' nullable-dtype behaviour.
+`tests/test_backends.py` covers byte-identical rendering separately, on
+frames that do round-trip.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+
+import polars as pl
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from showstats.showstats import make_stats_tbl
+from tests.helpers import stats_frame
+
+# Bounded well inside the range where a float is exactly representable and
+# formatting stays in its ordinary path. NaN and infinity are excluded:
+# "realistic" data does not contain them, and they have their own
+# assertions in test_scientific_conversion.py.
+FLOATS = st.floats(
+    min_value=-1e9,
+    max_value=1e9,
+    allow_nan=False,
+    allow_infinity=False,
+    allow_subnormal=False,
+    width=64,
+)
+INTS = st.integers(min_value=-(10**9), max_value=10**9)
+
+
+def _maybe_null(strategy):
+    """The same values, with roughly one null in five."""
+    return st.one_of(st.just(None), strategy, strategy, strategy, strategy)
+
+
+@st.composite
+def realistic_frames(draw) -> pl.DataFrame:
+    """A polars frame of numerical columns, some with nulls.
+
+    At least two rows, because the standard deviation of a single value is
+    undefined and prints blank — that case is asserted directly in
+    `test_single_row_has_no_standard_deviation` rather than being drawn
+    into every example.
+
+    Booleans are drawn without nulls: `to_pandas()` turns a nullable
+    boolean column into `object`, which showstats does not classify as
+    numerical at all, so the column would simply vanish from the pandas
+    table. That is worth knowing but it is not a fact about statistics.
+    """
+    n_rows = draw(st.integers(min_value=2, max_value=30))
+    kinds = draw(
+        st.lists(st.sampled_from(["float", "int", "bool"]), min_size=1, max_size=4)
+    )
+
+    data = {}
+    schema = {}
+    for i, kind in enumerate(kinds):
+        name = f"col_{i}_{kind}"
+        if kind == "float":
+            values = draw(_column(_maybe_null(FLOATS), n_rows))
+            schema[name] = pl.Float64
+        elif kind == "int":
+            values = draw(_column(_maybe_null(INTS), n_rows))
+            schema[name] = pl.Int64
+        else:
+            values = draw(_column(st.booleans(), n_rows))
+            schema[name] = pl.Boolean
+        data[name] = values
+
+    # An explicit schema so an all-null column keeps the dtype it was drawn
+    # as; inferred, it would come out as Null and land in a different part
+    # of the table.
+    return pl.DataFrame(data, schema=schema)
+
+
+def _column(values, n_rows):
+    return st.lists(values, min_size=n_rows, max_size=n_rows)
+
+
+def _parse(text: str):
+    """A rendered cell back to the value it represents, or None if blank."""
+    if text == "":
+        return None
+    if text == "true":
+        return 1.0
+    if text == "false":
+        return 0.0
+    return float(text)
+
+
+# The rendered number keeps two decimal places, or two decimal places of a
+# mantissa in [1, 10). So it is within 0.005 absolutely, or 0.005
+# relatively, of the statistic — this leaves a little room on top of that
+# for accumulation-order differences between backends. Tight enough to
+# catch the mistakes that matter: a population/sample standard deviation
+# mix-up differs by 1.3% at 40 rows, well outside it.
+REL_TOL = 6e-3
+ABS_TOL = 6e-3
+
+
+def assert_is(rendered: str, expected: float, label: str) -> None:
+    parsed = _parse(rendered)
+    assert parsed is not None, f"{label}: blank, expected {expected}"
+    assert math.isclose(parsed, expected, rel_tol=REL_TOL, abs_tol=ABS_TOL), (
+        f"{label}: printed {rendered!r}, expected {expected!r}"
+    )
+
+
+def check_column(row, values, label: str) -> None:
+    """Every cell of one row against the column it summarises."""
+    n_rows = len(values)
+    present = [float(v) for v in values if v is not None]
+
+    # Integer arithmetic, no floats: `ceil(a / b)` is `-(-a // b)`. Going
+    # via a float here would reproduce the very rounding bug this is meant
+    # to catch — ceil(14 / 25 * 100) is 57 in IEEE754, and 56 in fact.
+    missing = n_rows - len(present)
+    expected_na = -(-missing * 100 // n_rows)
+    assert row["NA%"] == expected_na, f"{label}: NA% for {missing}/{n_rows}"
+
+    if not present:
+        for stat in ("Avg", "SD", "Median", "Min", "Max"):
+            assert row[stat] == "", f"{label}: {stat} of an all-null column"
+        return
+
+    assert_is(row["Avg"], statistics.fmean(present), f"{label}: Avg")
+    assert_is(row["Median"], statistics.median(present), f"{label}: Median")
+    assert_is(row["Min"], min(present), f"{label}: Min")
+    assert_is(row["Max"], max(present), f"{label}: Max")
+
+    if len(present) >= 2:
+        # Sample standard deviation, matching polars, pandas and pyarrow,
+        # all of which default to ddof=1.
+        assert_is(row["SD"], statistics.stdev(present), f"{label}: SD")
+    else:
+        assert row["SD"] == "", f"{label}: SD of a single value"
+
+
+def rows_by_variable(result) -> dict:
+    frame = stats_frame(result)
+    name_column = frame.columns[0]
+    return {row[name_column]: row for row in frame.rows(named=True)}, frame.columns[0]
+
+
+@settings(
+    max_examples=75,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+@given(frame=realistic_frames())
+def test_numerical_statistics_are_correct(frame):
+    for backend, df in (("polars", frame), ("pandas", frame.to_pandas())):
+        rows, name_column = rows_by_variable(make_stats_tbl(df, "num"))
+
+        assert name_column == f"Col (N={frame.height})"
+        assert set(rows) == set(frame.columns), f"{backend}: one row per column"
+
+        for name in frame.columns:
+            values = frame.get_column(name).to_list()
+            check_column(rows[name], values, f"{backend}/{name}")
+
+
+@settings(max_examples=25, deadline=None)
+@given(
+    values=st.lists(FLOATS, min_size=2, max_size=20),
+    extra=st.lists(FLOATS, min_size=2, max_size=20),
+)
+def test_column_order_does_not_change_a_columns_statistics(values, extra):
+    """A column is summarised on its own, whatever it sits next to."""
+    n = min(len(values), len(extra))
+    alone = pl.DataFrame({"x": values[:n]})
+    together = pl.DataFrame({"x": values[:n], "y": extra[:n]})
+
+    rows_alone, _ = rows_by_variable(make_stats_tbl(alone, "num"))
+    rows_together, _ = rows_by_variable(make_stats_tbl(together, "num"))
+
+    assert rows_alone["x"] == rows_together["x"]
+
+
+def test_single_row_has_no_standard_deviation():
+    """Drawn out of the generated frames, so asserted directly instead."""
+    for df in (pl.DataFrame({"x": [1.5]}), pl.DataFrame({"x": [1.5]}).to_pandas()):
+        rows, _ = rows_by_variable(make_stats_tbl(df, "num"))
+        assert rows["x"]["SD"] == ""
+        assert rows["x"]["Avg"] == "1.5"
+
+
+@pytest.mark.parametrize("backend", ["polars", "pandas"])
+def test_all_null_column_prints_blank_statistics(backend):
+    df = pl.DataFrame({"x": [None, None, None]}, schema={"x": pl.Float64})
+    if backend == "pandas":
+        df = df.to_pandas()
+    rows, _ = rows_by_variable(make_stats_tbl(df, "num"))
+    assert rows["x"]["NA%"] == 100
+    for stat in ("Avg", "SD", "Median", "Min", "Max"):
+        assert rows["x"][stat] == ""

--- a/uv.lock
+++ b/uv.lock
@@ -5812,7 +5812,7 @@ wheels = [
 
 [[package]]
 name = "showstats"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "narwhals", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },

--- a/uv.lock
+++ b/uv.lock
@@ -1328,6 +1328,126 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.113.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "attrs", version = "25.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.9'" },
+    { name = "sortedcontainers", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/32/6513cd7256f38c19a6c8a1d5ce9792bcd35c7f11651989994731f0e97672/hypothesis-6.113.0.tar.gz", hash = "sha256:5556ac66fdf72a4ccd5d237810f7cf6bdcd00534a4485015ef881af26e20f7c7", size = 408897, upload-time = "2024-10-09T03:51:05.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/fa/4acb477b86a94571958bd337eae5baf334d21b8c98a04b594d0dad381ba8/hypothesis-6.113.0-py3-none-any.whl", hash = "sha256:d539180eb2bb71ed28a23dfe94e67c851f9b09f3ccc4125afad43f17e32e2bad", size = 469790, upload-time = "2024-10-09T03:51:02.629Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.141.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version > '3.9' and python_full_version < '3.10'",
+    "python_full_version == '3.9'",
+]
+dependencies = [
+    { name = "attrs", version = "26.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.9.*'" },
+    { name = "sortedcontainers", marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/20/8aa62b3e69fea68bb30d35d50be5395c98979013acd8152d64dc927e4cdb/hypothesis-6.141.1.tar.gz", hash = "sha256:8ef356e1e18fbeaa8015aab3c805303b7fe4b868e5b506e87ad83c0bf951f46f", size = 467389, upload-time = "2025-10-15T19:12:25.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/9a/f901858f139694dd669776983781b08a7c1717911025da6720e526bd8ce3/hypothesis-6.141.1-py3-none-any.whl", hash = "sha256:a5b3c39c16d98b7b4c3c5c8d4262e511e3b2255e6814ced8023af49087ad60b3", size = 535000, upload-time = "2025-10-15T19:12:21.659Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.163.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "sortedcontainers", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/08/4cbfa0327e9df00f57fc67f91847add2f0dd6c23408935273b095ee9a9f1/hypothesis-6.163.0.tar.gz", hash = "sha256:520480d4bd3a17557616c25923640953e360332c89d012fffcebd69857e674a9", size = 490145, upload-time = "2026-07-28T07:16:46.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/b1/3eea7a422de342bd0095a9672c3e03fe0466e4561a55499a1e01b4a9f098/hypothesis-6.163.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:331906cb029b6b360b8ebac3ec00c3cfa720037fe2efb294a503a1979c9a9a8f", size = 769898, upload-time = "2026-07-28T07:15:19.323Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/24/45b5c948c76c16ecf1e4ad1ca4a4a3fce55b3317ee172bc8230ff2956ae1/hypothesis-6.163.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:b4ad2134405d5345434c22dea96bbc12c85abcfc3c253a8063dbc9ff01164555", size = 765438, upload-time = "2026-07-28T07:16:04.69Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/72/7725039a75b3679dc445a169026b11860a0e67a600c4ffed49a42040a000/hypothesis-6.163.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50073f8e63c1e7d3403899755657a990d8bba7b5b5bff66b1c56796d4969bb28", size = 1094699, upload-time = "2026-07-28T07:15:56.668Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/fa/bcfa3879f303a302ec6e5f4d35b583924867a0821b42fa275f440f3b8dab/hypothesis-6.163.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8c5d1e6bad47edf6fb1d7406cf6d67314ac08325c63a49550d782a4596ea302b", size = 1123315, upload-time = "2026-07-28T07:16:40.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/e7fe2f0658db5182bb1d4b266d17f8f81cf3db82eeba27677ddfea13ac09/hypothesis-6.163.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ec3b709508ccd835d8ded1db025b7800618f2289a22a6bfd4927da5f4eb33c", size = 1144220, upload-time = "2026-07-28T07:15:20.617Z" },
+    { url = "https://files.pythonhosted.org/packages/90/14/c26f93a4693bfd83d7ba14b7043d986458026f6635d1b157bc2f1c56a59e/hypothesis-6.163.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:7cb3d927360fe73f9a06d646e6082237142ee39c24679c7133d22bf06dd03b45", size = 1099527, upload-time = "2026-07-28T07:16:17.955Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f5/4c1dde28d2e18e169dd6c471ef4bcf12abf3c6a3f4a1744bdabdbdf411ba/hypothesis-6.163.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3f3cceb4720a39127622fbf3bcebe1775b894372c53b5edddfdef10bbdeef9ec", size = 1136272, upload-time = "2026-07-28T07:16:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5b/54153509ed42cc17e1b65efe34a0c781f42fb04c902dc5f25486c537ec88/hypothesis-6.163.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59f5fdb8addb44c17520a60d50542d9db6ceba577bbf54efefa9c10ee20be140", size = 1268518, upload-time = "2026-07-28T07:15:42.991Z" },
+    { url = "https://files.pythonhosted.org/packages/81/86/f86f0d15d91b9cbff3546c1b8891950b2b08c0527e7494133fb2180e1b8b/hypothesis-6.163.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:f1fe222f50a1898e87a1e7323ab35f9e956278efabe4dd55a1342808206d05ad", size = 1396357, upload-time = "2026-07-28T07:15:26.696Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3a/c096b6b272f15e17e8e65c6ccfb2e1d167456ff5bbd9db33dca3185199f6/hypothesis-6.163.0-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:56ed585baab75cb98462c57ca88bbdc6a9d935a14118dd572fb476c3ecec2a06", size = 1269128, upload-time = "2026-07-28T07:16:11.902Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/9f/0807445874b3083a22c9a14a0ffc31bd0060ef3b408ce4cb31c20779cdf8/hypothesis-6.163.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2849c23b2e0fe2eef4c1ec336b01eac7ad7397c49fca43c264f59ec1e6046eac", size = 1311189, upload-time = "2026-07-28T07:16:08.545Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/de/3319aa8fcffd1641defc1c5eea1ad646a33d1b62528ef487a89752bc8079/hypothesis-6.163.0-cp310-abi3-win32.whl", hash = "sha256:b2ddcdaf6691101e06dc4a5add7b8c8fdf1e68daba599255a281f3f3550d3331", size = 655743, upload-time = "2026-07-28T07:16:30.966Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/48/36bc72910451e6e88b75e59a6ddbf0db34ff61a3b11c9439801dfd5fec20/hypothesis-6.163.0-cp310-abi3-win_amd64.whl", hash = "sha256:4ab0dadc09c537d4ac57e564039dfe7daf09c98375306d54bfc0fd6c218efcca", size = 661902, upload-time = "2026-07-28T07:16:34.407Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/4d/f20c3dfbe8cd897e1b33eda6f3107e15e451ef09e7f7a6749878f9d6f09d/hypothesis-6.163.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:67d1593941ede41052b4a35ec25b50d0e280358c7674ef7812d520010e7e8bdf", size = 770601, upload-time = "2026-07-28T07:16:20.056Z" },
+    { url = "https://files.pythonhosted.org/packages/29/aa/0c42c477575ed62170df7548f70c85f53cbfafeaf9ee501d995c885d27d1/hypothesis-6.163.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ee47c2cb1be03a052ebd3549dad07f636a98b3ccfd7acbe5e17b3b7da0ab9e37", size = 766343, upload-time = "2026-07-28T07:15:13.794Z" },
+    { url = "https://files.pythonhosted.org/packages/34/02/1edec861e6837d2d78f8a4ed87dbbb6844dc1c7197209cb8ab1a76cae830/hypothesis-6.163.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:00d3091b28de83c5116e0ccd9a4bcb28ef61d2aace5df91093bb22434fd2350c", size = 1095207, upload-time = "2026-07-28T07:15:47.452Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/8f/ecbd7356432d4bdeac33cb7285fd905f19d425adb9df10d18e45e733699e/hypothesis-6.163.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fae7305ae20fddeea09df317b920c45d3e20bfedbdb041f4db6ca5267c458189", size = 1144733, upload-time = "2026-07-28T07:16:03.147Z" },
+    { url = "https://files.pythonhosted.org/packages/23/43/cfc48bb8a33e060c3822cd8b58125e8fd5f4fa9d2eb250eafc50d62eeced/hypothesis-6.163.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:9be37b7ddf0af9e3f9112cd133afc34e78a56da1f96db5f2b4fc289fe1c4d1c3", size = 1269169, upload-time = "2026-07-28T07:15:35.737Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2b/62dd7a3589e7d2b38521889f7173c588c966eb7a27d70c61cfa2f4edb0dc/hypothesis-6.163.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:58be45d1737bf8c2e10cf29505c0f10f8a23d61bc82e4339182a6c8251cbc2d9", size = 1311512, upload-time = "2026-07-28T07:15:05.833Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/94/95d315013c4bea4d244e77cb10cb7097d3fa0fba851ef7a746daf4629e3b/hypothesis-6.163.0-cp310-cp310-win_amd64.whl", hash = "sha256:a2a20e9835d3c4b293a709ee6ef769bcb18c6ed4ef337a9e251c1a9496d5e8be", size = 661788, upload-time = "2026-07-28T07:16:23.768Z" },
+    { url = "https://files.pythonhosted.org/packages/63/80/796ac61dddb3ede550ea127e28e027a57a4ea481581c0bb27701fefd655a/hypothesis-6.163.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:213527755f0fc2b1f3721e73fd60023e2752a48f914e3e2df8d35111956ae5c8", size = 770366, upload-time = "2026-07-28T07:15:22.003Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/87/53924f322922bcfc05e40c79d432978333827b335fa9efa5fd1e8cbf3c90/hypothesis-6.163.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ca1b48bde68c528a79dec2a2859e05035802e5b1c9c3579f388c9de6ed6d0148", size = 766150, upload-time = "2026-07-28T07:15:16.151Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fb/b62480e6510052139d7b2a0219d4ae8bd52ccad0ed74db15dd61330a6962/hypothesis-6.163.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a3db868a943c814cc557104712d43bf609adfe5ea9f708f38377d366b4855f8", size = 1095046, upload-time = "2026-07-28T07:15:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d7/fa8aac7b47f41d0fe30fa270c5026f37a0c0c60d7b9a1a93dcc8fcfc50ce/hypothesis-6.163.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4159a1c2560e10de51b1c14956e277eb1b37526c9abef9e87c1e531760486448", size = 1144516, upload-time = "2026-07-28T07:16:32.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/26/c543c76d8a8b8f58f2d7adf0cb42e4928be3464e95f4fa9d7221b42ea9ce/hypothesis-6.163.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:ffdda3006a383a48f71a23b4f2b3fae3fe1b09af67925d885985f7ec34d66bcb", size = 1268886, upload-time = "2026-07-28T07:16:36.102Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/54/3613ef980cfa60f5c6bfbc533989d6c67b6b5f4e9e638fc6d010a5dd852f/hypothesis-6.163.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3b6cee2afe6c67b31a4a64b63a876e0b020befdc61daabea80f7a0e14f19203a", size = 1311472, upload-time = "2026-07-28T07:16:13.707Z" },
+    { url = "https://files.pythonhosted.org/packages/af/0c/cbaebc49fd5807a4b4286dea6e60d5330951e43115d002371bdfc99e70f8/hypothesis-6.163.0-cp311-cp311-win_amd64.whl", hash = "sha256:0a933aca9ebf9daf951d07cf01200c94c321b6ee0b42cc7b67675c9686d914c2", size = 661580, upload-time = "2026-07-28T07:15:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2c/74e989557efc429b28282cbe754c17fc74495467a72a1c94b5eb734fe374/hypothesis-6.163.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a57352efa938889ea9992667a5014c0fc870d03945de71918574d1cf28276378", size = 771445, upload-time = "2026-07-28T07:16:44.2Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/08/3ed2089d8cbeae125ea92879e82b99ea3a8b676c837710019249ccab379f/hypothesis-6.163.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0a0c396244c13805edcb73ff467c4c8178ccefc41c4ef5ed00a68e612fd773e9", size = 763070, upload-time = "2026-07-28T07:15:34.318Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1e/4e85a11f15e8ebd730f3b3e4a5d83653f7da482a4e81fa36958951d89b4a/hypothesis-6.163.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28a6cc1c25a6cc9b6ec079eaabd32ac769994831ecddd57123ce43c9056dcf34", size = 1093500, upload-time = "2026-07-28T07:15:49.539Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/29/c4790d2a5e6f48e6be5f868124a0d3c7e1d0102e2ca50503a0718e51289c/hypothesis-6.163.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd312b15044b1c1a0920a5827a830559b2d1fa380851cedf509f8b835309c5b9", size = 1143541, upload-time = "2026-07-28T07:15:44.393Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a8/01b72694e758449e9b530b72ecaf5f3625c80a3968de0d12ee6e784de22e/hypothesis-6.163.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b839dfd1342bb50570cb0c66b80322307cdb468abf14faf5df4dab022bc1b9ce", size = 1266326, upload-time = "2026-07-28T07:15:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a3/b3997add991e2fc6123b3c8dde3631f9f633db67ba23f5b2567736b50b9e/hypothesis-6.163.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c4f5be1482189c7b0a1dcac269fffe97a7d18cc04ac9a9a4d6613212dd87f38b", size = 1310536, upload-time = "2026-07-28T07:15:17.798Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/fe/36f576185d63ee0b4d94ed9564415de08baed4937e785b3695c8dd665c9c/hypothesis-6.163.0-cp312-cp312-win_amd64.whl", hash = "sha256:7ca7b20bf38d51e15f7808b0239791c4792b1709ce0c63093acaff56a09c31e6", size = 659021, upload-time = "2026-07-28T07:15:53.143Z" },
+    { url = "https://files.pythonhosted.org/packages/58/69/c474a3fa1c33d9a6e059e820221275d9c60eb10085f6164212c291856157/hypothesis-6.163.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:a16ebce774755a7a652bd44c62101dc914372ed1a98935969624848c9627b4a4", size = 771335, upload-time = "2026-07-28T07:15:14.988Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/8951688de58314780ba0af5bf2675709009dcc1fb568d244f2a03c4de8e9/hypothesis-6.163.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:40dfab6fe6a02a80abef81aebf88e53cd529e3f2f6ba3486b674a67b1f4a3512", size = 763020, upload-time = "2026-07-28T07:15:25.218Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d7/9eb7451400507f4b5c972c81c2bc57d0009597ea37295519a9645963a50e/hypothesis-6.163.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f28ad27193c1fbcfb52ef2ee63d2b721563525089e80962b4268b306dac45507", size = 1093415, upload-time = "2026-07-28T07:16:27.408Z" },
+    { url = "https://files.pythonhosted.org/packages/24/cc/c12c780676c7a4a4051d05e7b278a94bf1bb496ef31882881160f16866c9/hypothesis-6.163.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8aac96db8a6c7ee43aba2ee0d3c43893da1fb7c38ed54790c1be2b6d8fd87b96", size = 1143356, upload-time = "2026-07-28T07:16:01.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/c1/61c5ebdb77a3f259803e60a12f56de35f8b6d641a6219f798dcfa69dece3/hypothesis-6.163.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9d23f0f3a14bb6e6f99c793d340196dba4af95ba25bfcab624d1794f540f5e27", size = 1266375, upload-time = "2026-07-28T07:15:11.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/53/f3a89b4d21d89098d1dec749632aa0fece04f5d17a9e7e91c7f10596d55a/hypothesis-6.163.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b123b4995a7612f1130e2b2362c9a5d0568df887bf7e7bdb45c23af8cd5423c9", size = 1310257, upload-time = "2026-07-28T07:16:42.213Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e7/88e71c4cec0df68aa7a2fb251083c544f30697bd90fb4b1ed19de493ab81/hypothesis-6.163.0-cp313-cp313-win_amd64.whl", hash = "sha256:b268211e625cd550e361fc387bf1db5deb1e9cae0ce4041116f0a0aafeef7c06", size = 658983, upload-time = "2026-07-28T07:16:10.289Z" },
+    { url = "https://files.pythonhosted.org/packages/71/df/e3b2f0419cebcc86bba96a357d7ef37790538ed6b09f3183ae01f1fc3d23/hypothesis-6.163.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9105c66ea8dbc108adc42058bb7b65bd953f53ee178bf63bf9ebb0cded6c8c96", size = 771564, upload-time = "2026-07-28T07:15:28.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f8/a6f75e61ecd983029f8463bf007498155c4ed33114e6931e7aa3fbaf651e/hypothesis-6.163.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:e165f6cc2075059b7c95dac1612bfb25494f72d90f56880e84c288b089f8a896", size = 763164, upload-time = "2026-07-28T07:15:29.973Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/07/5193812567f6ca46c1f0cd02dabfd47c85d7c9e3287b8a870fc8150ee462/hypothesis-6.163.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cba5202f74e7e4cdb676d86f26e8cc1b4fdc88f7f58ba73c8ac45b6b22f3070", size = 1093916, upload-time = "2026-07-28T07:16:25.626Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0c/9d61f0e306499d734dc63ebe374b01c5f50be7072fd5e76eed25cc0b86ac/hypothesis-6.163.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7f706df6839dcc53f20833f2933cbcd126fd2fdee7c312e053de49df4b64e44", size = 1143547, upload-time = "2026-07-28T07:15:07.311Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b4/2a9eb04c9847ddf7e6b30bba8bc27b7efe5511d368335b6a41657b3f02dd/hypothesis-6.163.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:487ab8ec2f01a225d6a1e2ceadc5290cde2c691952bd2e7f76199cf82e06fb25", size = 1266755, upload-time = "2026-07-28T07:15:41.457Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f3/8d1903fbfcbf48b90bb5590826821afc9b4fc494391ab1fdfab9df23e928/hypothesis-6.163.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ae63dec6d1d467b7f4737455f81a7a82f14a41c14510937fcfbc726a085b5f8", size = 1310560, upload-time = "2026-07-28T07:15:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/47/2b/1a8c0457b44775d0aad369f21cbae8026b772a71aa917d1b956b7349b2a4/hypothesis-6.163.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:31dc46c48aa53c3ec92d03120978ca7f19b9cf96d195ed3fc93503f1433c94a6", size = 603067, upload-time = "2026-07-28T07:16:06.697Z" },
+    { url = "https://files.pythonhosted.org/packages/10/56/a9cd947064043035457dec0124ac2437ca72acf358b30cf203a229ad831b/hypothesis-6.163.0-cp314-cp314-win_amd64.whl", hash = "sha256:320b076bf6436f971f1c73ee651e60001226d1b4e341f2c4a1ca87248261ca03", size = 658931, upload-time = "2026-07-28T07:15:37.174Z" },
+    { url = "https://files.pythonhosted.org/packages/77/37/2d16317fda0ecd915cb094be9a9e8911106e693ed03a4d680de314711854/hypothesis-6.163.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:ab34c61d9249f1a8129cb4276062c04e3e47b5be8de6446e7c7fe11362d6fe43", size = 770142, upload-time = "2026-07-28T07:16:21.827Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/65/d80a9bfb7868f2c6c072a684993548391c56e0afa1972f79ee1fe168d91b/hypothesis-6.163.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f2f1b67a48da86d3e41c9445367b49a49f7efdb60fc8b5e3593f05e6afb2efbe", size = 761694, upload-time = "2026-07-28T07:15:31.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/01/c1f2515c638d2637300bb2fd6af129319eae75cdf2ed7804644535f64fb2/hypothesis-6.163.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c084749c115ea7918cf7efa144682783da17eec70d1276689182b871126e715", size = 1092511, upload-time = "2026-07-28T07:15:51.503Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f8/b3cd946308b5a09e52b075792610da310c0b7972bb1e8aa673400b86540c/hypothesis-6.163.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21e72e8d5818e5ef8cd6a2191c386e3fd1a6d9e3739cf97289b4d9b5dbc8e38d", size = 1142425, upload-time = "2026-07-28T07:16:15.626Z" },
+    { url = "https://files.pythonhosted.org/packages/85/96/b122859e6f7335b54aff759f573a813158d2249488450a75e76462ddaf61/hypothesis-6.163.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5a3ac6c62d49f7fe518dfe7fa924fa03aac839993702207802b0e45f9e1b0dab", size = 1264946, upload-time = "2026-07-28T07:15:23.848Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2e/e0226e8c904b8b4788eb52dacd303c91acbd260904abf64e8f9bad03c88a/hypothesis-6.163.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e568a3d766b7ba8df00e0c33efc4c6530cde14fbc72daabe4824eed211ed7596", size = 1309320, upload-time = "2026-07-28T07:16:29.218Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/48/e8bd29fed17c9608524b6a39db4a27b6eec7ce85bda78bba3ee0deebd80e/hypothesis-6.163.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8f22fb8218ba6a452bf9000fc656e1ed57625d17cc8a3871a0fcea3b1b69ebf", size = 659064, upload-time = "2026-07-28T07:16:00.075Z" },
+    { url = "https://files.pythonhosted.org/packages/39/db/d4e877b8639bbebedeff4a0511f5fc459c06a31d79a79bf75584eddda8da/hypothesis-6.163.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:002a9709345892279fb0e81b5a05b72d08cfe81f937339827be0d588607ca9b0", size = 771252, upload-time = "2026-07-28T07:15:08.694Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/3492490e997e5c8c9244a56728a623ca817577af3462fca5d1def060a066/hypothesis-6.163.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:52f16840add2eb02c2416f3b83cec4f527b6c19699f2d31eff4859233c715526", size = 767161, upload-time = "2026-07-28T07:15:54.972Z" },
+    { url = "https://files.pythonhosted.org/packages/51/73/37a4d4a6f3f0789fb2fddc851da957075fbe223706d1148ccc4dda825171/hypothesis-6.163.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34fc895691a2420595506eb17f3a104f2fa9039f013c0770a6cc2743ccaf6fed", size = 1096016, upload-time = "2026-07-28T07:15:09.821Z" },
+    { url = "https://files.pythonhosted.org/packages/48/46/20bc7801f8b539334dc0439c28753632a078c96d6732eccf1bd4880644d2/hypothesis-6.163.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ef8954e37c80e0c46e6161eef1c72c71059b95250e620a77bd646f6c7a52a2d", size = 1145797, upload-time = "2026-07-28T07:15:39.864Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/4d5c8feb78ed86e698d4e0665d3179eb657ae66d3606ffe096d8055aaa82/hypothesis-6.163.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d0838a28e9943d5b834ebae59b02adda76e2cd1e65caa808104c72102052057d", size = 662696, upload-time = "2026-07-28T07:15:38.519Z" },
+]
+
+[[package]]
 name = "id"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5842,6 +5962,9 @@ dev = [
     { name = "build", version = "1.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "hatchling", version = "1.27.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "hatchling", version = "1.31.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "hypothesis", version = "6.113.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "hypothesis", version = "6.141.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "hypothesis", version = "6.163.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "jupyter" },
     { name = "narwhals", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "narwhals", version = "2.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
@@ -5882,6 +6005,7 @@ provides-extras = ["pandas", "polars"]
 dev = [
     { name = "build", specifier = ">=1.2.1" },
     { name = "hatchling", specifier = ">=1.25.0" },
+    { name = "hypothesis", specifier = ">=6.113.0" },
     { name = "jupyter", specifier = ">=1.0.0" },
     { name = "narwhals", specifier = ">=1.40.0" },
     { name = "nbclient", specifier = "==0.10.0" },
@@ -5912,6 +6036,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5818,9 +5818,6 @@ dependencies = [
     { name = "narwhals", version = "1.42.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "narwhals", version = "2.21.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "narwhals", version = "2.24.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "polars", version = "1.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "polars", version = "1.36.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "polars", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.optional-dependencies]
@@ -5831,6 +5828,11 @@ pandas = [
     { name = "pyarrow", version = "17.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
     { name = "pyarrow", version = "25.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+polars = [
+    { name = "polars", version = "1.8.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "polars", version = "1.36.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "polars", version = "1.43.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.dev-dependencies]
@@ -5871,10 +5873,10 @@ dev = [
 requires-dist = [
     { name = "narwhals", specifier = ">=1.40.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.5.3" },
-    { name = "polars", specifier = ">=0.20.21" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=0.20.21" },
     { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=10.0.0" },
 ]
-provides-extras = ["pandas"]
+provides-extras = ["pandas", "polars"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Last PR of the #37 chain. **Stacked on #82 → #81 → #80 → #79 → #77 → #76.**

```toml
version = "0.2.0"
dependencies = ["narwhals >= 1.40.0"]
```

**Closes #37. Closes #42.**

## The actual proof

The built wheel, installed into a fresh environment with pandas and **no polars**:

```
$ uv run --isolated --with ./dist/showstats-0.2.0-py3-none-any.whl --with pandas --no-project python -c "…"
Installed 6 packages
version: 0.2.0
polars absent ✓
-Numerical columns--------------------------------------------------------------
 Col (N=3)  NA%  Avg  SD   Median  Min  Max
 a          0    2.0  1.0  2.0     1    3
```

Six packages, none of them polars. polars joins pandas as an optional extra (`pip install showstats[polars]`) and stays in the dev group, since the tests are written against it.

## Property tests, and the nine bugs they found

`tests/test_properties.py` generates frames with hypothesis and checks that **every cell of every table is the statistic it claims to be**, recomputed from the raw column in plain Python. Every dtype showstats classifies is drawn — both float widths and Decimal, all four signed and unsigned integer widths, booleans, strings, categoricals, enums, dates, datetimes, and the all-null Null dtype — and all three tables are checked, since the dtype decides which table a column lands in and each reports different statistics. Each frame is checked as polars and again converted to pandas.

**Nine bugs, none introduced by this chain.** Two are silent wrong answers:

| | |
|---|---|
| **`NA%` off by one point** | Computed as `count / rows * 100`, which polars evaluates as `60.00000000000001` for 6 of 10 — a column *exactly* 60% missing printed **61%**. Multiplying before dividing rounds once instead of twice; checked exhaustively over every count/rows pair up to 60 rows on all three backends: **35 wrong answers the old way, none the new**. |
| **Temporal median wrong on pandas** | pandas stores a missing timestamp as `NaT`, and casting that to an integer gives the **int64 minimum** rather than null — so missing rows joined the median as enormous negative numbers. Two nulls alongside 2020-01-01, 2020-06-01 and 2020-12-01 reported a median of **2020-01-01**. Not blank; wrong, and plausible enough never to be noticed. |
| `Uniques` counted null | A column of `a`, `b` and two nulls read as **three** uniques with only two ever listed — disagreeing with `NA%` and `Top N`, which treat null as missing. |
| pandas categoricals padded `Top N` | A pandas Categorical remembers categories it does not contain and `value_counts` reports them at zero, so a column holding only `alpha` listed **`alpha (67%)`, `beta (0%)`, `gamma (0%)`**. |
| Decimal beside a float crashed | Their statistics came back as `Decimal` and `float` in one list → `TypeError` from `nw.from_dict`. A Decimal column *alone* always worked, which is why it went unnoticed. |
| `NaT` printed literally | An all-null date column printed the string `NaT` on pandas 1.5 and blank on newer pandas. Blankness is now decided from the value, not from what the backend renders it as. |
| `show_stats(df)` silent | Printed *nothing at all* when no column was classifiable — reads as a hang. |
| all-null int `Min`/`Max` | Came back as `null` from `make_stats_tbl` where the float equivalent gives `""`. |
| pyarrow bool `stddev` | Raised `ArrowNotImplementedError`; Arrow has no kernel for it. |

Worth recording one thing about the tests themselves: my first `NA%` oracle used `math.ceil(missing / n * 100)` and **reproduced the very bug it was written to catch** (`ceil(14 / 25 * 100)` is 57 in IEEE754, and 56 in fact). It disagreed with the *fixed* implementation until the oracle stopped using floats and switched to `-(-a // b)`. A float oracle for a float-rounding bug is no oracle.

Two deliberate accommodations, both about the conversion rather than showstats: values are compared numerically (`to_pandas()` is not dtype-preserving — int-with-nulls becomes float64, Date becomes Datetime, Decimal becomes `object`), and which table a column belongs to is read off the result rather than assumed. `test_backends.py` still covers byte-identical rendering, on frames that do round-trip. Ties in `Top N` are asserted as a multiset, since `value_counts` may break them differently per backend.

~20s, stable across four `--hypothesis-seed=random` runs.

## One bug left alone: #86

**Date and datetime columns crash on a pyarrow table** — Arrow refuses the temporal-to-integer cast that pandas needs, and I found no expression-level route to a temporal median on pyarrow at all (five approaches tabulated in the issue). That needs a Series-level workaround, a different shape of change from a swapped expression, so it is **#86** rather than more scope here.

## 0.2.0

Two breaking changes — the dependency and the return type — which under SemVer's `0.x` rules is a **minor** bump. `0.x` is exactly where the API is not yet declared stable, so this is the strongest signal short of 1.0.0; the magnitude lives in the changelog. Not 1.0.0 yet because **#78** is open and its likely resolution drops Python 3.8, itself breaking — better that 1.0.0 means the API *and* the support matrix are settled.

Changelog dated **2026-07-29**; if the release slips, update it when you tag, since `publish.yaml`'s `check-version` guard compares the tag to `pyproject.toml`.

## `uv run nox` — the whole matrix, green

| session | result |
|---|---|
| lint | success |
| python_versions-3.8 … 3.12 | success (all five) |
| polars_pandas(polars=0.20.21) | success |
| polars_pandas(polars=1.4.1) | success |

**The 3.8 and 3.9 legs did not pass before this chain** — on `main` they fail five pandas tests (measured in #78). Four version-specific problems had to be fixed to get here, none of which CI can see, since it runs one interpreter:

1. `_ceil` used unary minus on an `Expr`; narwhals only added `__neg__` recently and Python 3.9's newest resolvable narwhals lacks it → 72 failures. Now `* -1`.
2. `top_cols` ordering used `replace_strict`, which needs polars ≥ 1 — a floor on a library that is no longer required. The permutation is worked out in Python instead.
3. The `NaT`-as-a-string bug above, which only appears on pandas 1.5.
4. `hypothesis` was missing from both nox sessions' install lists (they install an explicit set rather than syncing the dev group), so every session failed at collection.

The uint64 strategy stops at `2**63 - 1`: above that a value does not fit numpy's int64 and the pinned old stack raises `OverflowError`. Current polars and pandas print `18446744073709551615` correctly, so that is the old stack's limit, not showstats' — the generator stops short of it rather than the matrix being narrowed to hide it.

I also fixed the **subprocess harness** in `test_no_polars.py`: it now passes its own import root to the child. `pythonpath = ["src"]` only applies to the pytest process and `uv run` installs the project editable — nox does neither, so those four tests, the ones asserting the whole point of #37, were silently un-runnable under it.

## Cleanup

- `rewrite` marker registration and the `make burndown` target removed — redundant at zero.
- `xfail_strict = true` **stays**, with the comment rewritten to say why it earns its place on its own.
- `CLAUDE.md`'s "Rewrite in progress" section replaced by "No polars": what the finished state means for anyone editing `src/`.
- `noxfile.py`'s narwhals floor tracks `pyproject.toml`.

## Not done here, deliberately

- **`README.md`.** Generated; `readme.yaml` re-renders on any push to `main` touching `src/**`. The quantiles example will pick up the `Median` column polars was hiding.
- **`requires-python`.** Still `>= 3.8`, still in tension with narwhals ≥ 2.0 — that is #78.
- The two remaining warts from #72's list: `noxfile.py`'s unpinned `session.install("ruff")` and the `timing` Makefile target's wrong directory.

## The chain

| PR | |
|---|---|
| #72 | PR 0 — plumbing: strict xfail, markers, burndown |
| #73 | PR 0.5 — backend-agnostic assertions |
| #76 | PR 1 — the battery (16 xfails) + golden snapshots |
| #77 | slice 1 — one narwhals path for stats extraction; fixes pyarrow |
| #79 | slice 2 — `convert_df_scientific` |
| #80 | slice 3 — `make_dt` builds in the caller's backend |
| #81 | slice 4 — `form_stat_df`; return type follows input |
| #82 | slice 5 — hand-written formatter; burndown → 0 |
| **this** | drop polars; property tests; release 0.2.0; close #37 |

**Sixteen** user-facing bugs fixed across the chain. Fourteen were found by the xfail battery, the cross-backend tests or the property tests — not by reading the code. All in `changelog.md`.