### PR TITLE
Date the 0.1.0 changelog section

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - unreleased
+## [0.1.0] - 2026-07-27
 
 ### Removed
 


### PR DESCRIPTION
One line. v0.1.0 shipped on 2026-07-27 and is on PyPI, but the heading still said `unreleased`.

```diff
-## [0.1.0] - unreleased
+## [0.1.0] - 2026-07-27
```

Branched off `main` so it can go in now rather than waiting for the #37 stack.

**Note on #77:** slice 1 makes this same change (it had to — it adds an `## [Unreleased]` section above, and two sections both labelled "unreleased" would have read as competing). So merging this first will conflict with #77 on that one line. Resolve by taking either side — they are identical. Tell me when this lands and I'll rebase the stack so you don't have to touch it.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_