### PR TITLE
Summarise temporal columns on pyarrow, and fix three medians (#86)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Date and datetime columns raised `ArrowNotImplementedError: Unsupported
+  cast from date32[day] to int64` on a pyarrow table — every one of them.
+  The median went through Int64, which is the detour pandas needs, and Arrow
+  refuses that cast and has no quantile kernel for dates either. It is
+  computed from the sorted values now, which needs no cast (#86)
+- The median was approximate on pyarrow. `median()` maps to Arrow's
+  `approximate_median`, a t-digest: for the two values 0.00 and 0.02 it
+  answered 0.0. The median is the 50th percentile now, which is exact on
+  every backend — and the same call the `Q50` column makes, so the two agree
+  by construction rather than by coincidence (#86)
+- Quantiles of a narrow integer column overflowed: pandas answered 64.0 for
+  the median of an `Int8` column holding 0 and -128, where it is -64.0.
+  Interpolation happens in Int64 now. This affected the `Q50` column too,
+  not only `Median` (#86)
+- A statistic missing for every row — the standard deviation of a one-row
+  column, say — raised `ArrowInvalid: Invalid null value` on a pyarrow
+  table, because Arrow types an all-null column as `null` rather than as an
+  absent float (#86)
+
 ### Changed
 
 - **Breaking:** `requires-python` is now `>= 3.10`, up from `>= 3.8`, and the

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -150,30 +150,84 @@ def _blank_where_missing(name: str, rendered: nw.Expr) -> nw.Expr:
     return _branch((nw.col(name).is_null(), nw.lit("")), otherwise=rendered)
 
 
-def _median_expr(var: str, dtype) -> nw.Expr:
-    """Median of a column, for dtypes some backends refuse to take it on.
+def _is_temporal(dtype) -> bool:
+    return dtype == nw.Date or dtype == nw.Datetime or str(dtype).startswith("Datetime")
 
-    polars computes median() directly for booleans and datetimes, but the
-    pandas backend raises `median operation not supported for non-numeric
-    input type`. Casting to an integer, taking the median there and casting
-    back produces the same answer on every backend — for datetimes the cast
-    goes through the column's own dtype, so the time unit round-trips
-    correctly rather than being assumed.
 
-    Nulls are dropped before the cast, not left to median() to ignore.
-    pandas represents a missing datetime as NaT, and casting that to Int64
-    gives the int64 minimum rather than null — so the missing rows joined
-    the median as enormous negative numbers, and a column of two nulls and
-    the dates 2020-01-01, 2020-06-01, 2020-12-01 reported its median as
-    2020-01-01. Not blank; simply wrong, and plausible enough to go
-    unnoticed.
+# Integer widths that Int64 can hold, plus Boolean. Int64 and UInt64 are
+# absent on purpose: there is nothing wider to widen them to, and casting
+# a UInt64 past 2**63 into Int64 fails outright on polars and pyarrow.
+_WIDENABLE = (
+    nw.Boolean,
+    nw.Int8,
+    nw.Int16,
+    nw.Int32,
+    nw.UInt8,
+    nw.UInt16,
+    nw.UInt32,
+)
+
+
+def _widen_for_quantile(col: nw.Expr, dtype) -> nw.Expr:
+    """A column in a type a quantile can safely interpolate over.
+
+    A quantile lands between two values, and computing that in the
+    column's own width overflows: pandas answers 64.0 for the median of an
+    Int8 column holding 0 and -128, where it is -64.0. Booleans have no
+    quantile on any backend and need widening regardless.
+
+    Int64 rather than Float64, though the answer is a float either way.
+    Arrow refuses a lossy integer-to-float cast outright — `Integer value
+    9007199254740993 not in range: 0 to 9007199254740992` — so widening
+    through the float would fail on exactly the values that most need a
+    wider type.
     """
-    col = nw.col(var).drop_nulls()
-    if dtype == nw.Boolean:
-        return col.cast(nw.Int8).median()
-    if dtype == nw.Date or dtype == nw.Datetime or str(dtype).startswith("Datetime"):
-        return col.cast(nw.Int64).median().cast(dtype)
-    return col.median()
+    return col.cast(nw.Int64) if dtype in _WIDENABLE else col
+
+
+def _median_expr(var: str, dtype) -> nw.Expr:
+    """Median of a column, as the 50th percentile.
+
+    `median()` rather than `quantile(0.5)` would be the obvious call, but
+    narwhals maps it to Arrow's `approximate_median`, which is a t-digest:
+    for the two values 0.00 and 0.02 it answers 0.0 where the median is
+    0.01. `quantile(0.5, "linear")` is exact on all three backends, and it
+    is the same call the Q50 column makes — so Median and Q50 now agree by
+    construction rather than by coincidence.
+
+    Nulls are dropped rather than left to the aggregate to ignore, and the
+    column is widened first — see `_widen_for_quantile`. Temporal columns
+    do not come through here; see `_temporal_median`.
+    """
+    col = _widen_for_quantile(nw.col(var).drop_nulls(), dtype)
+    return col.quantile(0.5, interpolation="linear")
+
+
+def _temporal_median(series: nw.Series):
+    """Median of a date or datetime column, computed on the values.
+
+    Not an expression, because there is no expression that works. The
+    detour every backend needs is different: pandas cannot take median()
+    of a datetime at all, polars and pandas can cast temporal to Int64 and
+    back, and pyarrow can do neither — `Unsupported cast from date32[day]
+    to int64` — nor take a quantile of one. Casting through Int64 was the
+    old approach and it made pyarrow raise on any date column (#86).
+
+    Sorting and taking the middle works everywhere and needs no casts. For
+    an even count the answer is the midpoint of the two middle instants,
+    which is what the Int64 round-trip produced: `date + timedelta` keeps
+    whole days only, so a midpoint half a day along truncates down, and a
+    datetime keeps its full precision.
+
+    The column is sorted rather than listed out, so only the two middle
+    values are ever pulled into Python.
+    """
+    ordered = series.drop_nulls().sort()
+    count = len(ordered)
+    if count == 0:
+        return None
+    low, high = ordered[(count - 1) // 2], ordered[count // 2]
+    return low + (high - low) / 2
 
 
 def _std_expr(var: str, dtype) -> nw.Expr:
@@ -283,17 +337,22 @@ class _Table:
                     stat_name = f"{var}{sep}{function}"
                     if function.startswith(QUANTILE_PREFIX):
                         q = float(function[len(QUANTILE_PREFIX) :])
-                        col = nw.col(var)
-                        if vt == "num_bool":
-                            # narwhals has no quantile for booleans
-                            col = col.cast(nw.Int8)
+                        col = _widen_for_quantile(nw.col(var), schema[var])
                         # "linear" (numpy's and pandas' default) keeps the
                         # sequence self-consistent: Q0 == min, Q50 == median,
                         # Q100 == max. polars' own default of "nearest" would
                         # make Q50 disagree with the Median column.
                         expr = col.quantile(q, interpolation="linear").alias(stat_name)
                     elif function == "median":
-                        expr = _median_expr(var, schema[var]).alias(stat_name)
+                        # A temporal median has no expression that works on
+                        # every backend, so it is filled in below from the
+                        # values. The name is still registered here, since
+                        # make_dt reads the column order off stat_names_map.
+                        expr = (
+                            None
+                            if _is_temporal(schema[var])
+                            else _median_expr(var, schema[var]).alias(stat_name)
+                        )
                     elif function == "std":
                         expr = _std_expr(var, schema[var]).alias(stat_name)
                     elif function == "n_unique":
@@ -306,7 +365,8 @@ class _Table:
                         expr = nw.col(var).drop_nulls().n_unique().alias(stat_name)
                     else:
                         expr = getattr(nw.col(var), function)().alias(stat_name)
-                    expressions.append(expr)
+                    if expr is not None:
+                        expressions.append(expr)
                     stat_names_map[vt].append(stat_name)
         # Evaluate expressions.
         # Those conditions must always hold:
@@ -324,6 +384,10 @@ class _Table:
             stats = {}
         else:
             stats = df.select(expressions).rows(named=True)[0]
+
+        for vt in ("date", "datetime"):
+            for var in vars_map.get(vt, []):
+                stats[f"{var}{sep}median"] = _temporal_median(df[var])
 
         if "cat" in vars_map:
             # Top-3 counts likewise: one Series.value_counts per column,

--- a/src/showstats/_utils.py
+++ b/src/showstats/_utils.py
@@ -115,6 +115,15 @@ def convert_df_scientific(df, varnames: Iterable[str], thr: int = 4):
     already_narwhals = isinstance(df, (nw.DataFrame, nw.LazyFrame))
     frame = df if already_narwhals else nw.from_native(df)
 
+    # Everything below treats these as floats, so make them floats. A
+    # statistic that is missing for every row — the standard deviation of a
+    # one-row column, say — arrives as an all-null column, and Arrow types
+    # that as `null` rather than as a float that happens to be absent.
+    # `fill_null` on a null-typed column then raises `ArrowInvalid: Invalid
+    # null value`, since there is no float to put there. A no-op on the
+    # backends that infer a float type anyway.
+    frame = frame.with_columns(nw.col(name).cast(nw.Float64) for name in varnames)
+
     exprs_ex = []
     name_exponents = []
     for varname in varnames:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -2,6 +2,8 @@
 Tests to verify showstats works correctly with different dataframe backends.
 """
 
+from datetime import date, datetime
+
 import pandas as pd
 import polars as pl
 import pytest
@@ -141,6 +143,63 @@ def test_rendering_does_not_depend_on_the_input_backend(capsys, df, kwargs):
     from_backend = capsys.readouterr().out
     show_stats(MIXED_PL, **kwargs)
     assert from_backend == capsys.readouterr().out
+
+
+TEMPORAL_PL = pl.DataFrame(
+    {
+        "date_col": [date(2020, 1, 1), date(2020, 6, 1), None, date(2020, 12, 1)],
+        "dt_col": [
+            datetime(2020, 1, 1),  # noqa: DTZ001 — naive, as the column is
+            datetime(2020, 1, 3),  # noqa: DTZ001
+            None,
+            datetime(2020, 1, 2),  # noqa: DTZ001
+        ],
+    }
+)
+
+
+@pytest.mark.parametrize("backend", ["polars", "pandas", "pyarrow"])
+def test_temporal_columns_summarise_on_every_backend(backend):
+    """A date column on a pyarrow table used to raise outright.
+
+    The median went through Int64 — the detour pandas needs, since it
+    refuses median() on a datetime — and Arrow refuses that cast:
+    `Unsupported cast from date32[day] to int64`. It has no quantile
+    kernel for dates either, so there is no expression that works
+    everywhere; the median is computed from the sorted values instead
+    (#86).
+    """
+    frame = {
+        "polars": TEMPORAL_PL,
+        "pandas": TEMPORAL_PL.to_pandas(),
+        "pyarrow": TEMPORAL_PL.to_arrow(),
+    }[backend]
+
+    rows = {
+        row["Col"]: row
+        for row in stats_frame(make_stats_tbl(frame, "time")).rows(named=True)
+    }
+
+    # The middle of three real dates, with the null ignored rather than
+    # dragged in as the int64 minimum.
+    assert rows["date_col"]["Median"].startswith("2020-06-01")
+    assert rows["date_col"]["Min"].startswith("2020-01-01")
+    assert rows["date_col"]["Max"].startswith("2020-12-01")
+    assert rows["date_col"]["NA%"] == 25
+    assert rows["dt_col"]["Median"].startswith("2020-01-02")
+
+
+def test_temporal_median_of_an_even_count_is_the_midpoint():
+    """Two middle instants average, and a date truncates to whole days."""
+    even = pl.DataFrame({"d": [date(2020, 1, 1), date(2020, 1, 2)]})
+    row = stats_frame(make_stats_tbl(even, "time")).rows(named=True)[0]
+    assert row["Median"] == "2020-01-01"
+
+    even_dt = pl.DataFrame(
+        {"t": [datetime(2020, 1, 1), datetime(2020, 1, 2)]}  # noqa: DTZ001
+    )
+    row = stats_frame(make_stats_tbl(even_dt, "time")).rows(named=True)[0]
+    assert row["Median"] == "2020-01-01 12:00:00"
 
 
 def test_polars_vs_pandas_numeric_stats():

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -10,9 +10,10 @@ booleans, strings, categoricals, enums, dates, datetimes, and the all-null
 Null dtype — because the classification decides which of the three tables a
 column lands in, and each table reports different statistics.
 
-Every frame is checked twice, as polars and converted to pandas, since the
-point of the narwhals work is that the answer must not depend on which
-library holds the data.
+Every frame is checked three times — as polars, and converted to pandas
+and to pyarrow — since the point of the narwhals work is that the answer
+must not depend on which library holds the data. pyarrow was added after
+it turned out that date columns crashed there and nothing noticed (#86).
 
 Two deliberate accommodations for the conversion, neither of them about
 showstats:
@@ -326,7 +327,11 @@ CHECKS = {"num": check_numerical, "cat": check_categorical, "time": check_tempor
 )
 @given(frame=realistic_frames())
 def test_every_column_is_summarised_correctly(frame):
-    for backend, df in (("polars", frame), ("pandas", frame.to_pandas())):
+    for backend, df in (
+        ("polars", frame),
+        ("pandas", frame.to_pandas()),
+        ("pyarrow", frame.to_arrow()),
+    ):
         tables = tables_for(df)
         schema = nw.from_native(df, eager_only=True).schema
 
@@ -356,7 +361,7 @@ def test_showing_every_table_never_raises(frame):
     fixture: a function-scoped fixture is not reset between the inputs
     `@given` generates, so it would accumulate across examples.
     """
-    for df in (frame, frame.to_pandas()):
+    for df in (frame, frame.to_pandas(), frame.to_arrow()):
         buffer = io.StringIO()
         with redirect_stdout(buffer):
             show_stats(df, "all")


### PR DESCRIPTION
**Closes #86.** Stacked on #89 → #88.

## The reported crash

A date or datetime column raised on **any** pyarrow table. The median went through Int64 — the detour pandas needs, since it refuses `median()` on a datetime — and Arrow refuses that cast:

```
ArrowNotImplementedError: Unsupported cast from date32[day] to int64
```

I looked again for an expression that works on all three and there isn't one. `dt.timestamp()` *does* work on Arrow, which I had missed when filing the issue — but only one way: casting the result back is refused too, and it would change a Date column's rendering into a Datetime's.

So the temporal median is computed from the values: sort, take the middle, average the two middle instants for an even count. That reproduces what the Int64 round-trip did, truncation included — `date + timedelta` keeps whole days only, so a midpoint half a day along rounds down exactly as before. Only two values ever reach Python; the column is sorted rather than listed out. It sits next to the categorical top-3 counts, which are computed the same way for the same reason.

## Adding pyarrow to the property tests found three more

None of them temporal, and none of them would have shown up any other way. The property tests now run every generated frame through pyarrow as well as polars and pandas — which is what should have caught the original crash.

**1. The median was approximate on pyarrow.** narwhals maps `median()` to Arrow's `approximate_median`, a t-digest:

| values | true | polars | pandas | pyarrow |
|---|---|---|---|---|
| `0.00, 0.02` | 0.01 | 0.01 | 0.01 | **0.0** |
| `0, -128` (Int8) | -64.0 | -64.0 | -64.0 | **-128.0** |

The median is the 50th percentile now, which is exact on all three — and it is the same call the `Q50` column already makes, so `Median` and `Q50` agree by construction rather than by coincidence. The code has claimed that in a comment since the quantiles work; now it's true by construction.

**2. Quantiles of a narrow integer column overflow.** pandas answers **64.0** for the median of an `Int8` column holding 0 and -128. Interpolation happens in Int64 now. **This affected the `Q50` column too, not just `Median`** — it predates this PR by some way.

Two things I tried and rejected, both worth recording:

- **Widening through `Float64`** fails on Arrow, which refuses a lossy integer-to-float cast: `Integer value 9007199254740993 not in range: 0 to 9007199254740992`. It would have broken on exactly the large values that most need a wider type.
- **Widening `Int64`/`UInt64` too** breaks `uint64` above 2⁶³ on polars and pyarrow, which works today. There is nothing wider to widen them to, so they are left alone — deliberately, with a comment. (pyarrow already fails on `uint64` at its maximum; I checked, that's pre-existing on the base branch, not introduced here.)

**3. `ArrowInvalid: Invalid null value`** for a statistic missing on every row — the standard deviation of a one-row column, say. Arrow types an all-null column as `null` rather than as an absent float, so `fill_null` had nothing to put there. A one-row pyarrow table failed outright.

## Verification

- [x] `uv run pytest` → 104 passed
- [x] **Goldens unchanged** — none of this alters the printed table for polars
- [x] `uv run nox` green: lint, 3.10/3.11/3.12, both polars versions
- [x] Property tests stable across three random seeds with pyarrow included
- [x] Temporal medians agree across all three backends, and the even-count midpoint is pinned directly

New tests: `test_temporal_columns_summarise_on_every_backend` (parametrised over the three) and `test_temporal_median_of_an_even_count_is_the_midpoint`.

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_