### PR TITLE
Accept lazy frames (#85)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lazy frames are accepted. `show_stats(df.lazy())` used to raise
+  `TypeError: Cannot only use eager_only ... with polars.LazyFrame`; the
+  frame is collected at the door instead. Summarising is not a streaming
+  job — it reads every column several times over, once for the aggregate
+  row and again per categorical and temporal column — so collecting once up
+  front is what a lazy frame would end up doing anyway, without re-scanning
+  for each pass (#85)
+
 ### Fixed
 
 - Date and datetime columns raised `ArrowNotImplementedError: Unsupported

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from typing import Literal
 
 import narwhals as nw
-from narwhals.typing import IntoDataFrame
+from narwhals.typing import IntoFrame
 
 from showstats._utils import (
     TABLE_WIDTH,
@@ -34,8 +34,19 @@ def _warn_once(key: str, message: str) -> None:
 
 # Basic idea of these helper functions:
 #   table_type --> var_types --> functions
-def _check_input_maybe_try_transform(input: IntoDataFrame) -> nw.DataFrame:
-    df = nw.from_native(input, eager_only=True)
+def _check_input_maybe_try_transform(input: IntoFrame) -> nw.DataFrame:
+    """The input as an eager narwhals frame, collecting a lazy one.
+
+    Lazy frames are accepted and collected here rather than rejected
+    (#85). Summarising is not a streaming job — it reads every column
+    several times over: once for the aggregate row, again per categorical
+    column for its top values, again per temporal column for its median.
+    Collecting once up front is what a lazy frame would end up doing
+    anyway, only without re-scanning for each pass.
+    """
+    df = nw.from_native(input)
+    if isinstance(df, nw.LazyFrame):
+        df = df.collect()
     if df.shape[0] == 0 or df.shape[1] == 0:
         raise ValueError("Input data frame must have rows and columns")
     return df
@@ -262,7 +273,7 @@ class _Table:
 
     def __init__(
         self,
-        df: IntoDataFrame,
+        df: IntoFrame,
         table_type: TableType,
         top_cols: Iterable | None = None,
         quantiles: Iterable | None = None,

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 
 from typing import get_args
 
-from narwhals.typing import IntoDataFrame
+from narwhals.typing import IntoFrame
 
 from showstats._table import TableType, _Table
 
 
 def show_stats(
-    df: IntoDataFrame,
+    df: IntoFrame,
     table_type: TableType = "all",
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
@@ -20,7 +20,9 @@ def show_stats(
     for for optimal readability.
 
     Args:
-        df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
+        df: The input frame — polars, pandas, pyarrow or any other
+            narwhals-compatible frame. Lazy frames are accepted and
+            collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         table_type (str): All variables (default) = "num" or categorical = "cat"
@@ -56,12 +58,12 @@ def show_stats(
 
 
 def make_stats_tbl(
-    df: IntoDataFrame,
+    df: IntoFrame,
     table_type: TableType = "num",
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
     fold_quantiles: bool = True,
-) -> IntoDataFrame | None:
+) -> IntoFrame | None:
     """
     Builds table of summary statistics for the given DataFrame, configured
     for for optimal readability.
@@ -73,7 +75,9 @@ def make_stats_tbl(
     requested type.
 
     Args:
-        df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
+        df: The input frame — polars, pandas, pyarrow or any other
+            narwhals-compatible frame. Lazy frames are accepted and
+            collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         type (str): All variables (default) = "num" or categorical = "cat"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from showstats._table import (
     _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
 )
+from showstats.showstats import make_stats_tbl
 
 
 @pytest.mark.parametrize("bad", [1, 1.0, None, [], {}, {"a": []}])
@@ -63,6 +64,32 @@ def test_input_check(sample_df):
         assert sample_df.get_column("bool_col").equals(
             native_from_pandas.get_column("bool_col")
         )
+
+
+def test_lazy_input_is_collected():
+    """A LazyFrame is accepted, not rejected (#85).
+
+    Summarising reads every column several times — the aggregate row, then
+    each categorical column's top values, then each temporal column's
+    median — so it collects once at the door rather than making the engine
+    re-scan per pass.
+    """
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
+    df = _check_input_maybe_try_transform(lf)
+    assert isinstance(df, nw.DataFrame)
+    assert df.shape == (3, 2)
+
+
+def test_lazy_input_gives_the_same_answer_as_eager():
+    data = {"num": [1.5, 2.5, None, 4.5], "cat": ["x", "y", "x", None]}
+    eager = pl.DataFrame(data)
+    assert make_stats_tbl(eager.lazy(), "num").equals(make_stats_tbl(eager, "num"))
+    assert make_stats_tbl(eager.lazy(), "cat").equals(make_stats_tbl(eager, "cat"))
+
+
+def test_an_empty_lazy_frame_is_still_rejected():
+    with pytest.raises(ValueError, match="must have rows and columns"):
+        _check_input_maybe_try_transform(pl.LazyFrame({"a": []}))
 
 
 def test_input_check_pyarrow():


### PR DESCRIPTION
**Closes #85.** Stacked on #90 → #89 → #88.

## Before

```python
>>> show_stats(pl.LazyFrame({"a": [1, 2, 3]}))
TypeError: Cannot only use `eager_only` or `eager_or_interchange_only`
           with polars.LazyFrame
```

`_check_input_maybe_try_transform` passed `eager_only=True`, so anything lazy was refused at the door. It now takes the frame without that flag and collects if what arrives is lazy.

## The design decision: collected at the door, not kept lazy

Worth being explicit, since "supports lazy frames" could mean either.

Summarising is not a streaming job. It reads every column **several times over**: once for the aggregate row of every statistic, again per categorical column for its top-3 values, again per temporal column for its median. Staying lazy through that would mean either re-scanning the source for each pass, or rewriting those passes as group-bys and joins so the engine can fuse them — a large change for no clear gain, since the result is materialised regardless.

Collecting once up front is what a lazy frame would end up doing anyway, minus the re-scans. What this buys is that `show_stats(df.lazy())` works and `scan_parquet(...)` can be handed over directly, rather than the caller having to remember `.collect()`.

## What is unchanged

- **An empty lazy frame still raises `ValueError`** — the shape check happens after collecting.
- **Non-frames still raise `TypeError`.** `from_native` without `eager_only` is still strict about what it accepts; I checked all six cases the existing test covers (`1`, `1.0`, `None`, `[]`, `{}`, `{"a": []}`).
- The type hints move from `IntoDataFrame` to `IntoFrame`, which is the narwhals alias that admits both.

## Tests

- `test_lazy_input_is_collected` — a `LazyFrame` comes back as an eager `nw.DataFrame` of the right shape
- `test_lazy_input_gives_the_same_answer_as_eager` — the numerical and categorical tables are identical either way
- `test_an_empty_lazy_frame_is_still_rejected`

## Verification

- [x] `uv run pytest` → 107 passed
- [x] `uv run ruff check .` / `ruff format --check .` clean
- [x] Goldens unchanged

---
_Generated by [Claude Code](https://claude.ai/code/session_019pGQajosjwduxrexNaf8ya)_