### PR TITLE
Accept lazy frames (#85)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ was removed as incompatible with the narwhals direction.
 
 Input and statistic computation go through `narwhals`, so any
 narwhals-compatible frame (polars, pandas, pyarrow, ...) is accepted
-directly. Note that `_check_input_maybe_try_transform` returns a
-`nw.DataFrame`, not a polars one, and raises `TypeError` for plain Python
-literals (list/dict) — those are not narwhals-native frames.
+directly. `prepare_input` returns the Narwhals frame and its schema. It keeps
+lazy inputs lazy and raises `TypeError` for plain Python literals such as lists
+and dictionaries, because they are not Narwhals frames.
 
 Formatting, table assembly and rendering are still polars-internal
 (`make_dt`, `form_stat_df` and `show_one_table` build a `pl.LazyFrame`

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Lazy frames are accepted. `show_stats(df.lazy())` used to raise
+  `TypeError: Cannot only use eager_only ... with polars.LazyFrame`; the
+  frame is collected at the door instead. Summarising is not a streaming
+  job — it reads every column several times over, once for the aggregate
+  row and again per categorical and temporal column — so collecting once up
+  front is what a lazy frame would end up doing anyway, without re-scanning
+  for each pass (#85)
+
 ### Fixed
 
 - `make_stats_tbl(..., table_type="all")` now returns a dictionary of the

--- a/changelog.md
+++ b/changelog.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy frames are accepted. `show_stats(df.lazy())` used to raise
   `TypeError: Cannot only use eager_only ... with polars.LazyFrame`; the
-  frame is collected at the door instead. Summarising is not a streaming
-  job — it reads every column several times over, once for the aggregate
-  row and again per categorical and temporal column — so collecting once up
-  front is what a lazy frame would end up doing anyway, without re-scanning
+  frame is collected at the door instead. `make_stats_tbl` therefore always
+  returns an eager frame. An eager input keeps its native type, while a lazy
+  input uses the eager backend chosen by narwhals. Summarising is not a
+  streaming job. It reads every column several times, once for the aggregate
+  row and again per categorical and temporal column. Collecting once up front
+  is what a lazy frame would end up doing anyway, without re-scanning
   for each pass (#85)
 
 ### Fixed

--- a/changelog.md
+++ b/changelog.md
@@ -11,13 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Lazy frames are accepted. `show_stats(df.lazy())` used to raise
   `TypeError: Cannot only use eager_only ... with polars.LazyFrame`; the
-  frame is collected at the door instead. `make_stats_tbl` therefore always
-  returns an eager frame. An eager input keeps its native type, while a lazy
-  input uses the eager backend chosen by narwhals. Summarising is not a
-  streaming job. It reads every column several times, once for the aggregate
-  row and again per categorical and temporal column. Collecting once up front
-  is what a lazy frame would end up doing anyway, without re-scanning
-  for each pass (#85)
+  schema is read once and used to build the summary plan. Scalar statistics
+  and the row count are collected as one row. Categorical top values and
+  temporal medians use small queries that collect no more than three rows per
+  column. `make_stats_tbl` always returns an eager frame, but showstats does
+  not materialize the full lazy input (#85)
 
 ### Fixed
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,6 +19,7 @@ def lint(session):
 @nox.session(name="python_versions", python=["3.10", "3.11", "3.12"])
 def test(session):
     session.install(
+        "duckdb>=1.0.0",
         "pytest>=8.3.2",
         "hypothesis>=6.113.0",
         "polars>=0.20.21",
@@ -35,6 +36,7 @@ def test(session):
 @nox.session(name="polars_pandas", python="3.10")
 def test_polars_versions(session, polars_version, pandas_version):
     session.install(
+        "duckdb>=1.0.0",
         "pytest>=8.3.2",
         "hypothesis>=6.113.0",
         f"polars=={polars_version}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ polars = ["polars>=0.20.21"]
 # `dev` group by default. Runtime deps stay in [project.dependencies] above.
 dev = [
   "build>=1.2.1",
+  "duckdb>=1.0.0",
   "hatchling>=1.25.0",
   "hypothesis>=6.113.0",
   "jupyter>=1.0.0",

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Literal, get_args
 
 import narwhals as nw
-from narwhals.typing import IntoDataFrame
+from narwhals.typing import IntoFrame
 
 from showstats._utils import (
     TABLE_WIDTH,
@@ -36,8 +36,19 @@ def _warn_once(key: str, message: str) -> None:
 
 # Basic idea of these helper functions:
 #   table_type --> var_types --> functions
-def _check_input_maybe_try_transform(input: IntoDataFrame) -> nw.DataFrame:
-    df = nw.from_native(input, eager_only=True)
+def _check_input_maybe_try_transform(input: IntoFrame) -> nw.DataFrame:
+    """The input as an eager narwhals frame, collecting a lazy one.
+
+    Lazy frames are accepted and collected here rather than rejected
+    (#85). Summarising is not a streaming job — it reads every column
+    several times over: once for the aggregate row, again per categorical
+    column for its top values, again per temporal column for its median.
+    Collecting once up front is what a lazy frame would end up doing
+    anyway, only without re-scanning for each pass.
+    """
+    df = nw.from_native(input)
+    if isinstance(df, nw.LazyFrame):
+        df = df.collect()
     if df.shape[0] == 0 or df.shape[1] == 0:
         raise ValueError("Input data frame must have rows and columns")
     return df
@@ -681,7 +692,7 @@ class _Table:
 
     def __init__(
         self,
-        df: IntoDataFrame,
+        df: IntoFrame,
         table_type: TableType,
         top_cols: Iterable | None = None,
         quantiles: Iterable | None = None,

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -7,7 +7,7 @@ from decimal import Decimal
 from typing import Literal, get_args
 
 import narwhals as nw
-from narwhals.typing import IntoFrame
+from narwhals.typing import Frame, IntoFrame
 
 from showstats._utils import (
     TABLE_WIDTH,
@@ -34,24 +34,28 @@ def _warn_once(key: str, message: str) -> None:
     warnings.warn(message, stacklevel=3)
 
 
-# Basic idea of these helper functions:
-#   table_type --> var_types --> functions
-def _check_input_maybe_try_transform(input: IntoFrame) -> nw.DataFrame:
-    """The input as an eager narwhals frame, collecting a lazy one.
+@dataclass(frozen=True)
+class PreparedFrame:
+    """A Narwhals frame and the schema used to plan its summary."""
 
-    Lazy frames are accepted and collected here rather than rejected
-    (#85). Summarising is not a streaming job — it reads every column
-    several times over: once for the aggregate row, again per categorical
-    column for its top values, again per temporal column for its median.
-    Collecting once up front is what a lazy frame would end up doing
-    anyway, only without re-scanning for each pass.
-    """
-    df = nw.from_native(input)
-    if isinstance(df, nw.LazyFrame):
-        df = df.collect()
-    if df.shape[0] == 0 or df.shape[1] == 0:
+    frame: Frame
+    schema: Mapping[str, object]
+
+
+def prepare_input(input: IntoFrame) -> PreparedFrame:
+    """Convert an input frame and read its schema without collecting its rows."""
+    frame = nw.from_native(input)
+    schema = frame.collect_schema()
+    if len(schema) == 0:
         raise ValueError("Input data frame must have rows and columns")
-    return df
+    if isinstance(frame, nw.DataFrame) and frame.shape[0] == 0:
+        raise ValueError("Input data frame must have rows and columns")
+    return PreparedFrame(frame=frame, schema=schema)
+
+
+def _check_input_maybe_try_transform(input: IntoFrame) -> Frame:
+    """Compatibility wrapper that returns the prepared Narwhals frame."""
+    return prepare_input(input).frame
 
 
 def _get_cols_for_var_type(df_or_schema, var_type):
@@ -208,11 +212,11 @@ def _median_expr(var: str, dtype) -> nw.Expr:
     is the same call the Q50 column makes — so Median and Q50 now agree by
     construction rather than by coincidence.
 
-    Nulls are dropped rather than left to the aggregate to ignore, and the
-    column is widened first — see `_widen_for_quantile`. Temporal columns
-    do not come through here; see `_temporal_median`.
+    The aggregate ignores nulls, and the column is widened first. See
+    `_widen_for_quantile`. Temporal columns do not come through here. See
+    `_temporal_median`.
     """
-    col = _widen_for_quantile(nw.col(var).drop_nulls(), dtype)
+    col = _widen_for_quantile(nw.col(var), dtype)
     return col.quantile(0.5, interpolation="linear")
 
 
@@ -256,6 +260,14 @@ def _std_expr(var: str, dtype) -> nw.Expr:
     return col.std()
 
 
+def _mean_expr(var: str, dtype) -> nw.Expr:
+    """Mean with Boolean values represented as zero and one."""
+    col = nw.col(var)
+    if dtype == nw.Boolean:
+        return col.cast(nw.Int8).mean()
+    return col.mean()
+
+
 def _map_table_type_to_var_types(table_type):
     """Maps table type to var types"""
     if table_type == "all":
@@ -289,6 +301,7 @@ class SummaryPlan:
     """The columns and statistics that computation must produce."""
 
     config: SummaryConfig
+    schema: Mapping[str, object]
     vars_map: Mapping[VarType, tuple[str, ...]]
     funs_map: Mapping[VarType, tuple[str, ...]]
     stat_names_map: Mapping[VarType, tuple[str, ...]]
@@ -385,6 +398,7 @@ def build_summary_plan(
     }
     return SummaryPlan(
         config=config,
+        schema=dict(schema),
         vars_map=vars_map,
         funs_map=funs_map,
         stat_names_map=stat_names_map,
@@ -413,8 +427,19 @@ def build_stat_expressions(
                     )
                 elif function == "std":
                     expr = _std_expr(var, schema[var]).alias(stat_name)
+                elif function == "mean":
+                    expr = _mean_expr(var, schema[var]).alias(stat_name)
                 elif function == "n_unique":
-                    expr = nw.col(var).drop_nulls().n_unique().alias(stat_name)
+                    expr = (
+                        (
+                            nw.col(var).n_unique()
+                            - nw.col(var).is_null().any().cast(nw.Int64)
+                        )
+                        .cast(nw.Int64)
+                        .alias(stat_name)
+                    )
+                elif function == "null_count":
+                    expr = nw.col(var).null_count().cast(nw.Int64).alias(stat_name)
                 else:
                     expr = getattr(nw.col(var), function)().alias(stat_name)
                 if expr is not None:
@@ -422,30 +447,114 @@ def build_stat_expressions(
     return tuple(expressions)
 
 
-def compute_summary(df: nw.DataFrame, plan: SummaryPlan) -> SummaryResult:
-    """Execute a summary plan and return plain computed values."""
-    backend = nw.get_native_namespace(df)
-    num_rows = df.shape[0]
-    df = df.with_columns(
-        nw.col(name).cast(nw.Float64)
-        for name, dtype in df.schema.items()
-        if dtype == nw.Decimal
+_ROW_COUNT_STAT = "__showstats_row_count"
+_ROW_INDEX = "__showstats_row_index"
+
+
+def _collect_if_lazy(frame: Frame) -> nw.DataFrame:
+    return frame.collect() if isinstance(frame, nw.LazyFrame) else frame
+
+
+def _temporal_median_for_frame(df: Frame, var: str, count: int, row_index: str):
+    if count == 0:
+        return None
+    if isinstance(df, nw.DataFrame):
+        return _temporal_median(df[var])
+
+    low_index = (count - 1) // 2
+    high_index = count // 2
+    middle = (
+        df.select(var)
+        .drop_nulls(var)
+        .with_row_index(row_index, order_by=var)
+        .filter(nw.col(row_index).is_in([low_index, high_index]))
+        .sort(row_index)
+        .collect()
     )
-    expressions = build_stat_expressions(df.schema, plan)
-    stats = df.select(expressions).rows(named=True)[0] if expressions else {}
+    low, high = middle[var][0], middle[var][-1]
+    return low + (high - low) / 2
+
+
+def _top_counts_for_frame(
+    df: Frame, var: str, row_index: str
+) -> list[dict[str, object]]:
+    if isinstance(df, nw.DataFrame):
+        counts = df[var].drop_nulls().value_counts(sort=True)
+        return [row for row in counts.rows(named=True) if row["count"] > 0][:3]
+
+    native = df.to_native()
+    namespace = nw.get_native_namespace(df).__name__
+    if namespace == "polars":
+        indexed = nw.from_native(native.with_row_index(row_index))
+    elif namespace == "duckdb":
+        indexed = nw.from_native(
+            native.project(f"*, row_number() over () - 1 AS {row_index}")
+        )
+    else:
+        indexed = None
+
+    if indexed is None:
+        counts = (
+            df.group_by(var, drop_null_keys=True)
+            .agg(nw.len().alias("count"))
+            .sort(["count", var], descending=[True, False])
+            .head(3)
+            .collect()
+        )
+    else:
+        counts = (
+            indexed.group_by(var, drop_null_keys=True)
+            .agg(
+                nw.len().alias("count"),
+                nw.col(row_index).min().alias(row_index),
+            )
+            .sort(["count", row_index], descending=[True, False])
+            .head(3)
+            .select(var, "count")
+            .collect()
+        )
+    return counts.rows(named=True)
+
+
+def compute_summary(df: Frame, plan: SummaryPlan) -> SummaryResult:
+    """Collect computed summary values without collecting a lazy input."""
+    decimal_columns = [
+        name for name, dtype in plan.schema.items() if dtype == nw.Decimal
+    ]
+    if decimal_columns:
+        df = df.with_columns(nw.col(name).cast(nw.Float64) for name in decimal_columns)
+    expression_schema = {
+        name: nw.Float64 if name in decimal_columns else dtype
+        for name, dtype in plan.schema.items()
+    }
+    expressions = build_stat_expressions(expression_schema, plan)
+    aggregate = _collect_if_lazy(
+        df.select(nw.len().alias(_ROW_COUNT_STAT), *expressions)
+    )
+    stats = aggregate.rows(named=True)[0]
+    num_rows = stats.pop(_ROW_COUNT_STAT)
+    if num_rows == 0:
+        raise ValueError("Input data frame must have rows and columns")
+
+    row_index = _ROW_INDEX
+    while row_index in plan.schema:
+        row_index = f"{row_index}_"
 
     for var_type in ("date", "datetime"):
         for var in plan.vars_map.get(var_type, ()):
-            stats[f"{var}{_STAT_SEPARATOR}median"] = _temporal_median(df[var])
+            non_null_count = num_rows - stats[f"{var}{_STAT_SEPARATOR}null_count"]
+            stats[f"{var}{_STAT_SEPARATOR}median"] = _temporal_median_for_frame(
+                df, var, non_null_count, row_index
+            )
 
     for var in plan.vars_map.get("cat", ()):
-        counts = df[var].drop_nulls().value_counts(sort=True)
-        observed = [row for row in counts.rows(named=True) if row["count"] > 0]
-        stats[f"top_3{_STAT_SEPARATOR}{var}"] = observed[:3]
+        stats[f"top_3{_STAT_SEPARATOR}{var}"] = _top_counts_for_frame(
+            df, var, row_index
+        )
 
     return SummaryResult(
         plan=plan,
-        backend=backend,
+        backend=nw.get_native_namespace(aggregate),
         num_rows=num_rows,
         stats=stats,
     )
@@ -698,10 +807,10 @@ class _Table:
         quantiles: Iterable | None = None,
         fold_quantiles: bool = True,
     ):
-        frame = _check_input_maybe_try_transform(df)
+        prepared = prepare_input(df)
         config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
-        plan = build_summary_plan(frame.schema, config)
-        summary = compute_summary(frame, plan)
+        plan = build_summary_plan(prepared.schema, config)
+        summary = compute_summary(prepared.frame, plan)
 
         self.config = config
         self.plan = plan

--- a/src/showstats/_table.py
+++ b/src/showstats/_table.py
@@ -53,11 +53,6 @@ def prepare_input(input: IntoFrame) -> PreparedFrame:
     return PreparedFrame(frame=frame, schema=schema)
 
 
-def _check_input_maybe_try_transform(input: IntoFrame) -> Frame:
-    """Compatibility wrapper that returns the prepared Narwhals frame."""
-    return prepare_input(input).frame
-
-
 def _get_cols_for_var_type(df_or_schema, var_type):
     schema = df_or_schema.schema if hasattr(df_or_schema, "schema") else df_or_schema
     matching_cols = []

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -1,9 +1,11 @@
 # Central functions for table making
 from __future__ import annotations
 
+import narwhals as nw
 from narwhals.typing import IntoDataFrame, IntoFrame
 
 from showstats._table import (
+    SummaryConfig,
     TableType,
     build_summary_plan,
     compute_summary,
@@ -12,6 +14,21 @@ from showstats._table import (
     prepare_input,
     render_tables,
 )
+
+
+def _build_tables(
+    df: IntoFrame,
+    table_type: TableType,
+    top_cols: list[str] | str | None,
+    quantiles: list[float] | None,
+    fold_quantiles: bool,
+) -> tuple[dict[str, nw.DataFrame], SummaryConfig, int]:
+    """Build formatted tables and the information needed to render them."""
+    config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
+    prepared = prepare_input(df)
+    plan = build_summary_plan(prepared.schema, config)
+    summary = compute_summary(prepared.frame, plan)
+    return format_tables(summary), config, summary.num_rows
 
 
 def show_stats(
@@ -52,12 +69,10 @@ def show_stats(
         - Percentage of missing values is grouped into categories for easier interpretation.
         - Datetime columns are formatted as strings in the output.
     """
-    config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
-    prepared = prepare_input(df)
-    plan = build_summary_plan(prepared.schema, config)
-    summary = compute_summary(prepared.frame, plan)
-    tables = format_tables(summary)
-    render_tables(tables, config, summary.num_rows)
+    tables, config, num_rows = _build_tables(
+        df, table_type, top_cols, quantiles, fold_quantiles
+    )
+    render_tables(tables, config, num_rows)
 
 
 def make_stats_tbl(
@@ -107,11 +122,7 @@ def make_stats_tbl(
         - Percentage of missing values is grouped into categories for easier interpretation.
         - Datetime columns are formatted as strings in the output.
     """
-    config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
-    prepared = prepare_input(df)
-    plan = build_summary_plan(prepared.schema, config)
-    summary = compute_summary(prepared.frame, plan)
-    tables = format_tables(summary)
+    tables, _, _ = _build_tables(df, table_type, top_cols, quantiles, fold_quantiles)
     if table_type == "all":
         return {
             name: tables[name].to_native()

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -5,11 +5,11 @@ from narwhals.typing import IntoDataFrame, IntoFrame
 
 from showstats._table import (
     TableType,
-    _check_input_maybe_try_transform,
     build_summary_plan,
     compute_summary,
     format_tables,
     normalize_config,
+    prepare_input,
     render_tables,
 )
 
@@ -26,9 +26,9 @@ def show_stats(
     for for optimal readability.
 
     Args:
-        df: The input frame — polars, pandas, pyarrow or any other
-            narwhals-compatible frame. Lazy frames are accepted and
-            collected.
+        df: The input frame. Polars, pandas, PyArrow, and other
+            Narwhals compatible frames are accepted. For a lazy input,
+            only the planned summary results are collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         table_type (str): All variables (default) = "num" or categorical = "cat"
@@ -53,9 +53,9 @@ def show_stats(
         - Datetime columns are formatted as strings in the output.
     """
     config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
-    frame = _check_input_maybe_try_transform(df)
-    plan = build_summary_plan(frame.schema, config)
-    summary = compute_summary(frame, plan)
+    prepared = prepare_input(df)
+    plan = build_summary_plan(prepared.schema, config)
+    summary = compute_summary(prepared.frame, plan)
     tables = format_tables(summary)
     render_tables(tables, config, summary.num_rows)
 
@@ -72,18 +72,18 @@ def make_stats_tbl(
     for for optimal readability.
 
     The result is always eager. An eager input returns the same native frame
-    type. A lazy input returns the eager frame type chosen by narwhals when it
-    collects the input. For example, a polars LazyFrame returns a polars
-    DataFrame, while a DuckDB relation returns a pyarrow Table.
+    type. A lazy input returns the eager frame type chosen by Narwhals when it
+    collects the summary results. For example, a Polars LazyFrame returns a
+    Polars DataFrame, while a DuckDB relation returns a PyArrow table.
 
     For `table_type="all"`, the result is a dictionary containing each
     nonempty table under its `"time"`, `"num"`, or `"cat"` key. The function
     returns None when the input has no columns of a requested single type.
 
     Args:
-        df: The input frame — polars, pandas, pyarrow or any other
-            narwhals-compatible frame. Lazy frames are accepted and
-            collected.
+        df: The input frame. Polars, pandas, PyArrow, and other
+            Narwhals compatible frames are accepted. For a lazy input,
+            only the planned summary results are collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         type (str): All variables (default) = "num" or categorical = "cat"
@@ -108,9 +108,9 @@ def make_stats_tbl(
         - Datetime columns are formatted as strings in the output.
     """
     config = normalize_config(table_type, top_cols, quantiles, fold_quantiles)
-    frame = _check_input_maybe_try_transform(df)
-    plan = build_summary_plan(frame.schema, config)
-    summary = compute_summary(frame, plan)
+    prepared = prepare_input(df)
+    plan = build_summary_plan(prepared.schema, config)
+    summary = compute_summary(prepared.frame, plan)
     tables = format_tables(summary)
     if table_type == "all":
         return {

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -1,7 +1,7 @@
 # Central functions for table making
 from __future__ import annotations
 
-from narwhals.typing import IntoDataFrame
+from narwhals.typing import IntoDataFrame, IntoFrame
 
 from showstats._table import (
     TableType,
@@ -15,7 +15,7 @@ from showstats._table import (
 
 
 def show_stats(
-    df: IntoDataFrame,
+    df: IntoFrame,
     table_type: TableType = "all",
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
@@ -26,7 +26,9 @@ def show_stats(
     for for optimal readability.
 
     Args:
-        df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
+        df: The input frame — polars, pandas, pyarrow or any other
+            narwhals-compatible frame. Lazy frames are accepted and
+            collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         table_type (str): All variables (default) = "num" or categorical = "cat"
@@ -59,7 +61,7 @@ def show_stats(
 
 
 def make_stats_tbl(
-    df: IntoDataFrame,
+    df: IntoFrame,
     table_type: TableType = "num",
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
@@ -76,7 +78,9 @@ def make_stats_tbl(
     Returns None when the input has no columns of a requested single type.
 
     Args:
-        df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
+        df: The input frame — polars, pandas, pyarrow or any other
+            narwhals-compatible frame. Lazy frames are accepted and
+            collected.
         top_cols (list[str] | str | None, optional): Column or list of columns
             that should appear at the top of the summary table. Defaults to None.
         type (str): All variables (default) = "num" or categorical = "cat"

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -71,11 +71,14 @@ def make_stats_tbl(
     Builds table of summary statistics for the given DataFrame, configured
     for for optimal readability.
 
-    For a single table type, the result is a frame of the same kind as the
-    input. Polars gives polars back, pandas gives pandas, and so on. For
-    `table_type="all"`, the result is a dictionary containing each
-    nonempty table under its `"time"`, `"num"`, or `"cat"` key.
-    Returns None when the input has no columns of a requested single type.
+    The result is always eager. An eager input returns the same native frame
+    type. A lazy input returns the eager frame type chosen by narwhals when it
+    collects the input. For example, a polars LazyFrame returns a polars
+    DataFrame, while a DuckDB relation returns a pyarrow Table.
+
+    For `table_type="all"`, the result is a dictionary containing each
+    nonempty table under its `"time"`, `"num"`, or `"cat"` key. The function
+    returns None when the input has no columns of a requested single type.
 
     Args:
         df: The input frame — polars, pandas, pyarrow or any other

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -4,6 +4,7 @@ Tests to verify showstats works correctly with different dataframe backends.
 
 from datetime import date, datetime
 
+import duckdb
 import pandas as pd
 import polars as pl
 import pyarrow as pa
@@ -100,6 +101,22 @@ def test_pyarrow_backend_categorical_top_values():
 def test_pyarrow_backend_all_types(capsys):
     show_stats(MIXED_PA, "all")
     assert "int_col" in capsys.readouterr().out
+
+
+def test_duckdb_lazy_input_collects_to_pyarrow(capsys):
+    relation = duckdb.from_arrow(MIXED_PA)
+
+    result = make_stats_tbl(relation, "num")
+    assert isinstance(result, pa.Table)
+    assert (
+        stats_frame(result).rows()
+        == stats_frame(make_stats_tbl(MIXED_PA, "num")).rows()
+    )
+
+    show_stats(relation, "all")
+    lazy_output = capsys.readouterr().out
+    show_stats(MIXED_PA, "all")
+    assert lazy_output == capsys.readouterr().out
 
 
 @pytest.mark.parametrize(

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -80,8 +80,7 @@ def test_pandas_backend_basic():
 def test_pyarrow_backend_basic():
     """pyarrow input, which used to be accepted at the door and then die.
 
-    `_check_input_maybe_try_transform` has always taken pyarrow tables
-    (test_utils.py::test_input_check_pyarrow), but `_Table.__init__` read
+    `prepare_input` accepts pyarrow tables, but `_Table.__init__` read
     the aggregate row with `.iloc[0]` whenever the frame was not polars —
     treating "not polars" as "pandas". Every pyarrow table therefore
     raised AttributeError.

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -36,6 +36,22 @@ def test_make_stats_tbl_quantiles(sample_df):
     assert "Q75" in res_num.columns
 
 
+@pytest.mark.parametrize("table_type", ["num", "cat"])
+def test_make_stats_tbl_collects_polars_lazy_input(table_type):
+    result = make_stats_tbl(MIXED_PL.lazy(), table_type)
+    assert isinstance(result, pl.DataFrame)
+    assert result.equals(make_stats_tbl(MIXED_PL, table_type))
+
+
+def test_make_stats_tbl_collects_deferred_scan(tmp_path):
+    path = tmp_path / "input.parquet"
+    MIXED_PL.write_parquet(path)
+
+    result = make_stats_tbl(pl.scan_parquet(path), "num")
+    assert isinstance(result, pl.DataFrame)
+    assert result.equals(make_stats_tbl(MIXED_PL, "num"))
+
+
 @pytest.mark.parametrize(("df", "native_type"), BACKENDS)
 def test_make_stats_tbl_returns_the_input_type(df, native_type):
     """The return follows the input, rather than always being polars.

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -52,6 +52,23 @@ def test_make_stats_tbl_collects_deferred_scan(tmp_path):
     assert result.equals(make_stats_tbl(MIXED_PL, "num"))
 
 
+def test_lazy_numeric_input_collects_only_the_summary(monkeypatch):
+    collected_source_shapes = []
+    original_collect = pl.LazyFrame.collect
+
+    def record_source_collection(frame, *args, **kwargs):
+        plan = frame.explain()
+        result = original_collect(frame, *args, **kwargs)
+        if "__showstats_row_count" in plan:
+            collected_source_shapes.append(result.shape)
+        return result
+
+    monkeypatch.setattr(pl.LazyFrame, "collect", record_source_collection)
+    make_stats_tbl(MIXED_PL.lazy(), "num")
+
+    assert collected_source_shapes == [(1, 13)]
+
+
 def test_make_stats_tbl_collects_lazy_input_for_all_tables():
     result = make_stats_tbl(MIXED_PL.lazy(), "all")
     expected = make_stats_tbl(MIXED_PL, "all")

--- a/tests/test_make_tbl.py
+++ b/tests/test_make_tbl.py
@@ -52,6 +52,15 @@ def test_make_stats_tbl_collects_deferred_scan(tmp_path):
     assert result.equals(make_stats_tbl(MIXED_PL, "num"))
 
 
+def test_make_stats_tbl_collects_lazy_input_for_all_tables():
+    result = make_stats_tbl(MIXED_PL.lazy(), "all")
+    expected = make_stats_tbl(MIXED_PL, "all")
+
+    assert list(result) == ["num", "cat"]
+    assert all(isinstance(table, pl.DataFrame) for table in result.values())
+    assert all(result[name].equals(expected[name]) for name in expected)
+
+
 @pytest.mark.parametrize(("df", "native_type"), BACKENDS)
 def test_make_stats_tbl_returns_the_input_type(df, native_type):
     """The return follows the input, rather than always being polars.

--- a/tests/test_pyspark.py
+++ b/tests/test_pyspark.py
@@ -1,0 +1,74 @@
+"""Optional PySpark tests.
+
+Run these tests with:
+
+    uv run --with "pyspark>=3.5" python -m pytest tests/test_pyspark.py -m integration -v
+"""
+
+from datetime import date, datetime
+
+import pyarrow as pa
+import pytest
+
+from showstats.showstats import make_stats_tbl
+from tests.helpers import stats_frame
+
+pytestmark = pytest.mark.integration
+
+
+def _spark_timestamp(day: int, hour: int) -> datetime:
+    """Build a value for Spark's timestamp type, which has no time zone."""
+    return datetime(2020, 1, day, hour)  # noqa: DTZ001
+
+
+@pytest.fixture(scope="module")
+def spark():
+    pytest.importorskip("pyspark")
+    from pyspark.sql import SparkSession
+
+    session = (
+        SparkSession.builder.master("local[1]")
+        .appName("showstats-tests")
+        .config("spark.sql.session.timeZone", "UTC")
+        .config("spark.ui.enabled", "false")
+        .config("spark.ui.showConsoleProgress", "false")
+        .getOrCreate()
+    )
+    session.sparkContext.setLogLevel("ERROR")
+    yield session
+    session.stop()
+
+
+def test_pyspark_lazy_input_matches_pyarrow(spark):
+    from pyspark.sql import functions as sf
+
+    rows = [
+        (1, True, "a", date(2020, 1, 1), _spark_timestamp(1, 1)),
+        (2, False, "a", date(2020, 1, 2), _spark_timestamp(2, 2)),
+        (3, True, "a", date(2020, 1, 3), _spark_timestamp(3, 3)),
+        (4, False, "b", date(2020, 1, 4), _spark_timestamp(4, 4)),
+        (None, True, "b", None, None),
+        (6, None, "c", date(2020, 1, 6), _spark_timestamp(6, 6)),
+    ]
+    columns = ["number", "active", "category", "day", "moment"]
+    spark_rows = [
+        (*row[:-1], row[-1].isoformat(sep=" ") if row[-1] is not None else None)
+        for row in rows
+    ]
+    spark_frame = spark.createDataFrame(spark_rows, columns).withColumn(
+        "moment", sf.col("moment").cast("timestamp")
+    )
+    arrow_frame = pa.table(
+        {name: [row[position] for row in rows] for position, name in enumerate(columns)}
+    )
+
+    spark_result = make_stats_tbl(spark_frame, "all")
+    arrow_result = make_stats_tbl(arrow_frame, "all")
+
+    assert list(spark_result) == list(arrow_result)
+    for table_type in arrow_result:
+        assert isinstance(spark_result[table_type], pa.Table)
+        assert (
+            stats_frame(spark_result[table_type]).rows()
+            == stats_frame(arrow_result[table_type]).rows()
+        )

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -41,6 +41,14 @@ def test_show_subsets(sample_df, capsys):
     assert "categorical_col" in captured.out
 
 
+def test_show_lazy_matches_eager_for_all_types(sample_df, capsys):
+    show_stats(sample_df.lazy(), "all")
+    lazy_output = capsys.readouterr().out
+
+    show_stats(sample_df, "all")
+    assert lazy_output == capsys.readouterr().out
+
+
 def test_show_empty(sample_df, capsys):
     show_stats(sample_df.select("U", "int_col"), "cat")
     captured = capsys.readouterr()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from showstats._table import (
     _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
 )
-from showstats.showstats import make_stats_tbl
 
 
 @pytest.mark.parametrize("bad", [1, 1.0, None, [], {}, {"a": []}])
@@ -78,13 +77,6 @@ def test_lazy_input_is_collected():
     df = _check_input_maybe_try_transform(lf)
     assert isinstance(df, nw.DataFrame)
     assert df.shape == (3, 2)
-
-
-def test_lazy_input_gives_the_same_answer_as_eager():
-    data = {"num": [1.5, 2.5, None, 4.5], "cat": ["x", "y", "x", None]}
-    eager = pl.DataFrame(data)
-    assert make_stats_tbl(eager.lazy(), "num").equals(make_stats_tbl(eager, "num"))
-    assert make_stats_tbl(eager.lazy(), "cat").equals(make_stats_tbl(eager, "cat"))
 
 
 def test_an_empty_lazy_frame_is_still_rejected():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from showstats._table import (
     _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
 )
+from showstats.showstats import make_stats_tbl
 
 
 @pytest.mark.parametrize("bad", [1, 1.0, None, [], {}, {"a": []}])
@@ -63,6 +64,32 @@ def test_input_check(sample_df):
         assert sample_df.get_column("bool_col").equals(
             native_from_pandas.get_column("bool_col")
         )
+
+
+def test_lazy_input_is_collected():
+    """A LazyFrame is accepted, not rejected (#85).
+
+    Summarising reads every column several times — the aggregate row, then
+    each categorical column's top values, then each temporal column's
+    median — so it collects once at the door rather than making the engine
+    re-scan per pass.
+    """
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
+    df = _check_input_maybe_try_transform(lf)
+    assert isinstance(df, nw.DataFrame)
+    assert df.shape == (3, 2)
+
+
+def test_lazy_input_gives_the_same_answer_as_eager():
+    data = {"num": [1.5, 2.5, None, 4.5], "cat": ["x", "y", "x", None]}
+    eager = pl.DataFrame(data)
+    assert make_stats_tbl(eager.lazy(), "num").equals(make_stats_tbl(eager, "num"))
+    assert make_stats_tbl(eager.lazy(), "cat").equals(make_stats_tbl(eager, "cat"))
+
+
+def test_an_empty_lazy_frame_is_still_rejected():
+    with pytest.raises(ValueError, match="must have rows and columns"):
+        _check_input_maybe_try_transform(pl.LazyFrame({"a": []}))
 
 
 def test_input_check_pyarrow():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,8 @@ import polars as pl
 import pytest
 
 from showstats._table import (
-    _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
+    prepare_input,
 )
 from showstats.showstats import make_stats_tbl
 
@@ -17,20 +17,20 @@ def test_input_check_rejects_non_frames(bad):
     the first line ever ran: the rest were unreachable once it raised.
     """
     with pytest.raises(TypeError):
-        _check_input_maybe_try_transform(bad)
+        prepare_input(bad)
 
 
 def test_input_check(sample_df):
-    df2 = _check_input_maybe_try_transform(sample_df)
+    df2 = prepare_input(sample_df).frame
     # Now returns a narwhals DataFrame
     assert isinstance(df2, nw.DataFrame)
     assert df2.shape == sample_df.shape
     # Test with valid dict input (convert through polars first)
-    result2 = _check_input_maybe_try_transform(pl.DataFrame({"x": [1, 2, 3]}))
+    result2 = prepare_input(pl.DataFrame({"x": [1, 2, 3]})).frame
     assert isinstance(result2, nw.DataFrame)
 
     sample_df_pandas = sample_df.to_pandas()
-    sample_df_from_pandas = _check_input_maybe_try_transform(sample_df_pandas)
+    sample_df_from_pandas = prepare_input(sample_df_pandas).frame
     # Those wont be the same in general but only roughly
     assert sample_df.shape == sample_df_from_pandas.shape
     assert list(sample_df.columns) == list(sample_df_from_pandas.columns)
@@ -68,9 +68,9 @@ def test_input_check(sample_df):
 
 def test_lazy_input_stays_lazy_during_preparation():
     lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
-    df = _check_input_maybe_try_transform(lf)
-    assert isinstance(df, nw.LazyFrame)
-    assert df.collect_schema().names() == ["a", "b"]
+    prepared = prepare_input(lf)
+    assert isinstance(prepared.frame, nw.LazyFrame)
+    assert list(prepared.schema) == ["a", "b"]
 
 
 def test_an_empty_lazy_frame_is_still_rejected():
@@ -82,7 +82,7 @@ def test_input_check_pyarrow():
     import pyarrow as pa
 
     tbl = pa.table({"a": [1, 2, 3], "b": ["x", "y", "z"]})
-    df = _check_input_maybe_try_transform(tbl)
+    df = prepare_input(tbl).frame
     assert isinstance(df, nw.DataFrame)
     assert df.shape == (3, 2)
     assert list(df.columns) == ["a", "b"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from showstats._table import (
     _check_input_maybe_try_transform,
     _map_cols_and_funs_for_var_type,
 )
+from showstats.showstats import make_stats_tbl
 
 
 @pytest.mark.parametrize("bad", [1, 1.0, None, [], {}, {"a": []}])
@@ -65,23 +66,16 @@ def test_input_check(sample_df):
         )
 
 
-def test_lazy_input_is_collected():
-    """A LazyFrame is accepted, not rejected (#85).
-
-    Summarising reads every column several times — the aggregate row, then
-    each categorical column's top values, then each temporal column's
-    median — so it collects once at the door rather than making the engine
-    re-scan per pass.
-    """
+def test_lazy_input_stays_lazy_during_preparation():
     lf = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", "y", "x"]})
     df = _check_input_maybe_try_transform(lf)
-    assert isinstance(df, nw.DataFrame)
-    assert df.shape == (3, 2)
+    assert isinstance(df, nw.LazyFrame)
+    assert df.collect_schema().names() == ["a", "b"]
 
 
 def test_an_empty_lazy_frame_is_still_rejected():
     with pytest.raises(ValueError, match="must have rows and columns"):
-        _check_input_maybe_try_transform(pl.LazyFrame({"a": []}))
+        make_stats_tbl(pl.LazyFrame({"a": []}))
 
 
 def test_input_check_pyarrow():

--- a/uv.lock
+++ b/uv.lock
@@ -552,11 +552,53 @@ wheels = [
 ]
 
 [[package]]
+name = "duckdb"
+version = "1.5.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/19/e57151753576373c6696a12022648546cca6038e8833fda2908ee2342d9b/duckdb-1.5.5.tar.gz", hash = "sha256:72f33ee57ca7595b23957671a2cc7f7fe2be0ecc2d68f63abedcfcaa3a5c1238", size = 18066741, upload-time = "2026-07-22T10:55:17.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/d4/298acf9331a80b3ce6ac64dd940e7e13f4058fb69d18914445f02e3c7bfe/duckdb-1.5.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3b805507f88171b428b21c966c30e9a3d54e30b24528918a44ed0032542bc26f", size = 32702934, upload-time = "2026-07-22T10:53:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/c489fb63d64b2e7ee109ce8460bdede003a0f256e5b41a03a2a1c4764058/duckdb-1.5.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b08e19cc856220d8a26fa62abc2264b349aff67255e9373c6a3f607addd56dc6", size = 17343604, upload-time = "2026-07-22T10:53:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/27/effa80a15b1f0c61c235622f797868485359e8c9ad6a8e358e7a0c479151/duckdb-1.5.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a17e6a922e42a5c06ed2353fe78c5dff2610f6632d603836f9606ad0bf754079", size = 15488179, upload-time = "2026-07-22T10:53:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/07/21212345c8d24ba62dceaa20be3b21f5c46f1510b1b42ce93bb058afe0c4/duckdb-1.5.5-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1bdc38922c365c37720149f90d90b1e9823eb82dad6830855b5f87537fa6fc0c", size = 19367323, upload-time = "2026-07-22T10:53:30.23Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d0/10371ae875fb4b5ef61bb892743b4b2e90c512b371fdf29317deb744857d/duckdb-1.5.5-cp310-cp310-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e238060db5ca59879882a6e9b015e2c65d5c64ddf281ba1d7a9a2033764152cf", size = 21476568, upload-time = "2026-07-22T10:53:33.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/09568ce617dd7bc0757b3d7b6a981660b9e4f0b7594de8ed776755eae740/duckdb-1.5.5-cp310-cp310-win_amd64.whl", hash = "sha256:4acc72798ba1885a9c17d1242903d2cd502f13b1271c7677f7cab25d8578eceb", size = 13156129, upload-time = "2026-07-22T10:53:37.55Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/c2/b62ec24d57bb8df4e24b0b58f7f8facb32f5fdb9f1895aed9e9fcdded168/duckdb-1.5.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:1b543841b0ae18a9c982345cfa3987e9c065d3a4b0f067daa473d92d1e65f528", size = 32708371, upload-time = "2026-07-22T10:53:41.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ce/769171ba45f0b73632dc3bc3108d891e81dd6c6bbfba630a34a75b4dcc0f/duckdb-1.5.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a925d06c2a4c3b64553d6cc1aced5028d376d4479bed689a7d47e9b1dccd80a", size = 17343979, upload-time = "2026-07-22T10:53:44.951Z" },
+    { url = "https://files.pythonhosted.org/packages/46/59/a8e3384ee916e00d5dcf985194c1511d61978540778a1e96fa47f9fb3e0d/duckdb-1.5.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0c42757cb34722144bd4dfb94b6f336339e7b2468f6813fa7fa9a319ba07bab4", size = 15493704, upload-time = "2026-07-22T10:53:47.912Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/1d/9840179c2607b90523a2884a129c4d4e6dbdc1178ba62a976c1043beba88/duckdb-1.5.5-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e72f9e1a4f90a5c8483ad4d540e495bf0834ba61c360b52499a573d7ed62a3f", size = 19366574, upload-time = "2026-07-22T10:53:51.876Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/55/f9641a4eebcc2f4df631287d6c3b9ed2eea3b92644f93acbad825e3972b6/duckdb-1.5.5-cp311-cp311-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b9b6f86ed85d4ef5e0211eaebf75d057bd8bb520bba438a95dd0f4e42234bbfe", size = 21477952, upload-time = "2026-07-22T10:53:55.575Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/3a/07c3556e37a5c97b95917b029c8fdde4a25fbd76a660bacdac195cf20dcb/duckdb-1.5.5-cp311-cp311-win_amd64.whl", hash = "sha256:9f4287f97ccf0c1f3d471e7115be2b067cbf99627e2d34bffd462dd64703cddc", size = 13156986, upload-time = "2026-07-22T10:53:58.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/ff/07b48eef2078ca033847e9caa46cc7633b714c5f91ad1ce091c8ca89d792/duckdb-1.5.5-cp311-cp311-win_arm64.whl", hash = "sha256:179633a3fc6296c75d57c69c1e239fa9e5cdcb670fd1dbff88a02663f932905c", size = 14001317, upload-time = "2026-07-22T10:54:01.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/40/2e05d324400fdaa5656c9f48d6298da421cb034d85e509fa0e6e325cf04b/duckdb-1.5.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d4dd65f8941a604b947e0b9b4b4f7165988e29a23ec0b69b4038520956d9933e", size = 32753858, upload-time = "2026-07-22T10:54:05.514Z" },
+    { url = "https://files.pythonhosted.org/packages/79/15/5ceb58ffb5bb8a62b3fd7abb39c41467cdf94850ece02e6d88664dfc75ce/duckdb-1.5.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33db46679b071f108d57139493dee2d37e1f5efcf5c5c039c2969eed11a6c8a7", size = 17368293, upload-time = "2026-07-22T10:54:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/5c/bf02da0b354fe83cca4f95a4fbf762181af466f7d551ab2a093f7698882a/duckdb-1.5.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f0b88535a5d86fdd63dba6ea02ab68c003dfb9e4892b11256ef24c4da208baae", size = 15509131, upload-time = "2026-07-22T10:54:12.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/a9/5f1f09da421d8e930e0b063d11c1b3f90363f40ede74438cd188afdd13a2/duckdb-1.5.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f316eae2323d9a851883fdf2dee91c1f9efe251ab33e14a2272f82a913422ed6", size = 19391959, upload-time = "2026-07-22T10:54:15.551Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/98/6549769f158126fa64fd6c1ac2eb59a18282146c939867a3eb31b7c1db07/duckdb-1.5.5-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7a6d2d11859d82a936ebdcb30ce3d8a1cbb3e990bff05c12abb9b54c44fa7bd1", size = 21510909, upload-time = "2026-07-22T10:54:19.681Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b7/5753b41d3124838f868f9f523362812d9fc45409e9e4dd70dcbb0a25826e/duckdb-1.5.5-cp312-cp312-win_amd64.whl", hash = "sha256:ddfbdb096c11d51ee22492397d342c90a82e62c5d09961477895934d0a25372f", size = 13168544, upload-time = "2026-07-22T10:54:22.789Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/28/44b679c7d46245f8398feae7edac959d1b83d4eb143e25b3fce0630b78bd/duckdb-1.5.5-cp312-cp312-win_arm64.whl", hash = "sha256:2725d2b9ace3a4e75d72fc5a239f6a44b502c580edadb8fb2676db772c5f9282", size = 13988684, upload-time = "2026-07-22T10:54:26.003Z" },
+    { url = "https://files.pythonhosted.org/packages/47/37/4a38116e7700720fd152c666292214fd3abdf916496991296d8d1f66efbf/duckdb-1.5.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd98829b67788609017e65c761bd42a5dd0f9129441bed8bda4d6881ccf819f0", size = 32754294, upload-time = "2026-07-22T10:54:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/66/42/7d392f1ba1eee0eaf4ab4c8c7a604bfe3536cd63f979cf5c98798664f807/duckdb-1.5.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:feead93c56679b79592d437c62975d39cb67adedffa7592c763baf8160ac7366", size = 17368211, upload-time = "2026-07-22T10:54:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/0a6f4fa60562faa615e55e15bd1953a2f2b17a8edd8105e5cda215e43457/duckdb-1.5.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:49c963d9469373d7aba8d750d9ea565ab823e94166efed953f184dd9b169b98c", size = 15509136, upload-time = "2026-07-22T10:54:36.369Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/cb/023c89f51978545b9fab318581bba0c457a58e7530d2d933e54ae7d8647c/duckdb-1.5.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a736217825461732b5442d05a220f3da2e23a0dae114efbf08c9bf171b53098a", size = 19392147, upload-time = "2026-07-22T10:54:39.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/c5/41bef391fb8b23dbc133c9f2ba016e7a7a8124513d2cc1b430f1897d87e4/duckdb-1.5.5-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:078e6a60dd8eedde5832f45422ca5c4a6b8c837aeabd8a56ca0b7d933f588053", size = 21511060, upload-time = "2026-07-22T10:54:42.788Z" },
+    { url = "https://files.pythonhosted.org/packages/07/9f/c44dfc1f924ac29b3252dc1b91393c01d009dbfe9f8ed33f10b986151bd1/duckdb-1.5.5-cp313-cp313-win_amd64.whl", hash = "sha256:6826504277dba513c0c5d71d828456c94d729c9d2482f94b2e289f90a9167e28", size = 13168028, upload-time = "2026-07-22T10:54:46.127Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/88/591384b2cd59abddd6f5dc175e60374f9abae6064429f0c4402854c10f44/duckdb-1.5.5-cp313-cp313-win_arm64.whl", hash = "sha256:baa9c5702002fabb559ded2a39008f9f421fcbc7237d388b8213eff1e08858de", size = 13989955, upload-time = "2026-07-22T10:54:49.262Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/56/12c65bfa2d2605b81981b264788891bcf11ec72227889554cead5d8d13b9/duckdb-1.5.5-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8e6413dd40facb7b8ab21bd844450cd8f549b29e138635be9cf090ef4d2049e2", size = 32761946, upload-time = "2026-07-22T10:54:53.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/46/682ce155f17e0d2822d4f13ee3db9ca4b5b7c2da61b841b2629035e1f4bc/duckdb-1.5.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:64078acfd16541132ac6e191eb81b2845554444a0305cc1aa581ba107e514aa8", size = 17375069, upload-time = "2026-07-22T10:54:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ce/a24bcbd3289c8f305a430759c5fc12242740b4af3e17f7593f3a34e333d2/duckdb-1.5.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c11775cc99a447618d5f1840126db17f2652f3eae05529df4f81f40e2df7151", size = 15519791, upload-time = "2026-07-22T10:55:00.681Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/3a01afbc615c1d418c0de58a6b68ac5ce2a8563232c0464bfbc2ce552398/duckdb-1.5.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77bbc1e6ba12e1e06f9020117bdf848627ecfdf36f907550e62e008e6109dece", size = 19398251, upload-time = "2026-07-22T10:55:04.168Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/43/3a5e81d1728f4d234c79bfe385808ee7c04834f7c37a4b5c257459c25614/duckdb-1.5.5-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fbf0f2d48b43c6c304d00463b463c27ead6c4b01c3c1816b750f728decf71afe", size = 21513851, upload-time = "2026-07-22T10:55:07.864Z" },
+    { url = "https://files.pythonhosted.org/packages/91/41/fc7c829172c60ca22485251eab285f4f1a0d87b486a024c726f21471d86e/duckdb-1.5.5-cp314-cp314-win_amd64.whl", hash = "sha256:9dc826c4b50e64f6c4e4d07a3a9cb075ef70ba3899dc43ec5493dc3d7b04b353", size = 13691858, upload-time = "2026-07-22T10:55:11.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/95d9216b79e9273689d7ebce125a54503ed0c9bd7da931f0265888e99779/duckdb-1.5.5-cp314-cp314-win_arm64.whl", hash = "sha256:63e48d4b74b15aeacd688976432a7225163df8c226eddeb8536bba2d4d4ff433", size = 14470180, upload-time = "2026-07-22T10:55:14.445Z" },
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2806,6 +2848,7 @@ polars = [
 [package.dev-dependencies]
 dev = [
     { name = "build" },
+    { name = "duckdb" },
     { name = "hatchling" },
     { name = "hypothesis" },
     { name = "jupyter" },
@@ -2837,6 +2880,7 @@ provides-extras = ["pandas", "polars"]
 [package.metadata.requires-dev]
 dev = [
     { name = "build", specifier = ">=1.2.1" },
+    { name = "duckdb", specifier = ">=1.0.0" },
     { name = "hatchling", specifier = ">=1.25.0" },
     { name = "hypothesis", specifier = ">=6.113.0" },
     { name = "jupyter", specifier = ">=1.0.0" },


### PR DESCRIPTION
Closes #85.

## What

Accept lazy frames in `show_stats` and `make_stats_tbl`. Showstats reads the schema once, builds the summary plan, and collects the scalar statistics and row count as one row.

Categorical top values and temporal medians use small lazy queries that return at most three rows per column. `make_stats_tbl` returns an eager result in the backend chosen by Narwhals.

## Why

Callers can pass `scan_parquet(...)`, a DuckDB relation, or a Spark DataFrame without materializing the full input in Python. The dataframe engine evaluates the summary expressions and can optimize the query.

## Verify

```shell
uv run --locked pytest -q -m "not integration"
uv run --locked ruff check .
uv run --locked ruff format --check .
SPARK_LOCAL_IP=127.0.0.1 uv run --with "pyspark>=3.5" python -m pytest tests/test_pyspark.py -m integration -q
```

The normal suite passes with 131 tests. The optional Spark test passes separately and compares every summary table with the same PyArrow data.

## Risk

Exact statistics still scan the required source columns. Categorical and temporal sections can execute extra small queries.