### PR TITLE
Test the public API and return all summary tables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `make_stats_tbl(..., table_type="all")` now returns a dictionary of the
+  nonempty numerical, categorical, and temporal tables instead of returning
+  `None`.
+
+### Fixed
+
 - Date and datetime columns raised `ArrowNotImplementedError: Unsupported
   cast from date32[day] to int64` on a pyarrow table — every one of them.
   The median went through Int64, which is the detour pandas needs, and Arrow

--- a/src/showstats/showstats.py
+++ b/src/showstats/showstats.py
@@ -61,16 +61,16 @@ def make_stats_tbl(
     top_cols: list[str] | str | None = None,
     quantiles: list[float] | None = None,
     fold_quantiles: bool = True,
-) -> IntoDataFrame | None:
+) -> IntoDataFrame | dict[str, IntoDataFrame] | None:
     """
     Builds table of summary statistics for the given DataFrame, configured
     for for optimal readability.
 
-    The result is a frame of the same kind as the input — a polars frame in
-    gives a polars frame back, pandas gives pandas, and so on — so callers
-    do not take on a dependency on some other dataframe library just to
-    read the summary. Returns None when the input has no columns of the
-    requested type.
+    For a single table type, the result is a frame of the same kind as the
+    input. Polars gives polars back, pandas gives pandas, and so on. For
+    `table_type="all"`, the result is a dictionary containing each
+    nonempty table under its `"time"`, `"num"`, or `"cat"` key.
+    Returns None when the input has no columns of a requested single type.
 
     Args:
         df: The input DataFrame (supports polars, pandas, and other narwhals-compatible dataframes).
@@ -104,6 +104,12 @@ def make_stats_tbl(
         )
     _table = _Table(df, table_type, top_cols, quantiles, fold_quantiles)
     _table.form_stat_df(table_type)
+    if table_type == "all":
+        return {
+            name: _table.stat_dfs[name].to_native()
+            for name in ("time", "num", "cat")
+            if name in _table.stat_dfs
+        }
     # Return None if no columns of this type were found
     stat_df = _table.stat_dfs.get(table_type, None)
     if stat_df is None:

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 
 import pandas as pd
 import polars as pl
+import pyarrow as pa
 import pytest
 
 from showstats import show_stats
@@ -99,6 +100,62 @@ def test_pyarrow_backend_categorical_top_values():
 def test_pyarrow_backend_all_types(capsys):
     show_stats(MIXED_PA, "all")
     assert "int_col" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("frame", "native_type"),
+    [
+        pytest.param(
+            pl.DataFrame(
+                {
+                    "number": [1, 2],
+                    "category": ["a", "b"],
+                    "date": [date(2020, 1, 1), date(2020, 1, 2)],
+                }
+            ),
+            pl.DataFrame,
+            id="polars",
+        ),
+        pytest.param(
+            pd.DataFrame(
+                {
+                    "number": [1, 2],
+                    "category": ["a", "b"],
+                    "date": pd.to_datetime(["2020-01-01", "2020-01-02"]),
+                }
+            ),
+            pd.DataFrame,
+            id="pandas",
+        ),
+        pytest.param(
+            pa.table(
+                {
+                    "number": [1, 2],
+                    "category": ["a", "b"],
+                    "date": pa.array(
+                        [date(2020, 1, 1), date(2020, 1, 2)], type=pa.date32()
+                    ),
+                }
+            ),
+            pa.Table,
+            id="pyarrow",
+        ),
+    ],
+)
+def test_make_stats_tbl_all_returns_each_table_in_the_input_backend(frame, native_type):
+    result = make_stats_tbl(frame, "all")
+
+    assert list(result) == ["time", "num", "cat"]
+    assert all(isinstance(table, native_type) for table in result.values())
+    assert stats_frame(result["time"])["Col"].to_list() == ["date"]
+    assert stats_frame(result["num"])["Col"].to_list() == ["number"]
+    assert stats_frame(result["cat"])["Col"].to_list() == ["category"]
+
+
+def test_make_stats_tbl_all_omits_empty_table_types():
+    result = make_stats_tbl(pl.DataFrame({"number": [1, 2]}), "all")
+
+    assert list(result) == ["num"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,102 @@
+"""End-to-end tests for the package-level public API."""
+
+from datetime import date
+
+import polars as pl
+import pytest
+
+from showstats import make_stats_tbl, show_stats
+
+MIXED = pl.DataFrame(
+    {
+        "second_number": [10, 20, 30, 40],
+        "first_number": [1.0, 2.0, 3.0, 4.0],
+        "category": ["a", "b", "a", None],
+        "date": [date(2024, 1, day) for day in range(1, 5)],
+    }
+)
+
+
+def test_show_stats_runs_end_to_end_from_the_package(capsys):
+    show_stats(
+        MIXED,
+        table_type="all",
+        top_cols="first_number",
+        quantiles=[0.25],
+        fold_quantiles=False,
+    )
+
+    output = capsys.readouterr().out
+    assert "Date and datetime columns (N=4)" in output
+    assert "Numerical columns (N=4)" in output
+    assert "Categorical columns (N=4)" in output
+    assert "first_number" in output
+    assert "Q25" in output
+    assert "category" in output
+    assert "date" in output
+
+
+def test_make_stats_tbl_runs_end_to_end_from_the_package():
+    tables = make_stats_tbl(
+        MIXED,
+        table_type="all",
+        top_cols="first_number",
+        quantiles=[0.25],
+        fold_quantiles=False,
+    )
+
+    assert list(tables) == ["time", "num", "cat"]
+    assert all(isinstance(table, pl.DataFrame) for table in tables.values())
+    assert tables["time"]["Col"].to_list() == ["date"]
+    assert tables["num"]["Col"].to_list() == ["first_number", "second_number"]
+    assert tables["num"].columns == [
+        "Col",
+        "NA%",
+        "Avg",
+        "Median",
+        "SD",
+        "Q25",
+        "Min",
+        "Max",
+    ]
+    assert tables["cat"]["Col"].to_list() == ["category"]
+    assert tables["cat"]["Top 1"].to_list() == ["a (50%)"]
+
+
+def test_make_stats_tbl_default_returns_the_numerical_table():
+    table = make_stats_tbl(MIXED)
+
+    assert table["Col"].to_list() == ["first_number", "second_number"]
+    assert "category" not in table["Col"].to_list()
+    assert "date" not in table["Col"].to_list()
+
+
+def test_make_stats_tbl_returns_none_when_the_type_is_absent():
+    assert make_stats_tbl(MIXED.select("category"), table_type="num") is None
+
+
+@pytest.mark.parametrize("api", [show_stats, make_stats_tbl])
+def test_public_api_rejects_an_invalid_table_type(api):
+    with pytest.raises(ValueError, match="table_type 'invalid' not supported"):
+        api(MIXED, table_type="invalid")
+
+
+@pytest.mark.parametrize("api", [show_stats, make_stats_tbl])
+@pytest.mark.parametrize(
+    "empty",
+    [
+        pytest.param(pl.DataFrame(), id="no-columns"),
+        pytest.param(
+            pl.DataFrame({"value": []}, schema={"value": pl.Int64}), id="no-rows"
+        ),
+    ],
+)
+def test_public_api_rejects_empty_dataframes(api, empty):
+    with pytest.raises(ValueError, match="must have rows and columns"):
+        api(empty)
+
+
+@pytest.mark.parametrize("api", [show_stats, make_stats_tbl])
+def test_public_api_rejects_out_of_range_quantiles(api):
+    with pytest.raises(ValueError, match=r"quantiles must lie in \[0, 1\]"):
+        api(MIXED, table_type="num", quantiles=[1.01])


### PR DESCRIPTION
## What

Add package level tests that call `show_stats` and `make_stats_tbl` through the public `showstats` import. Make `make_stats_tbl(..., table_type="all")` return each available summary table in a dictionary.

## Why

The accepted `all` option returned `None`, and several public validation and return paths had no end to end tests.

Closes #94.

## Verify

`uv run pytest`

`uv run ruff check .`

`uv run ruff format --check .`

## Risk

The behavior change is limited to `make_stats_tbl` calls that request `table_type="all"`; reverting this pull request restores the old result.