### PR TITLE
Test the declared dependency floors (#78)

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,3 +22,9 @@ jobs:
 
       - name: Run tests
         run: uv run pytest -v -m "not integration"
+
+      - name: Install minimum supported Python
+        run: uv python install 3.10
+
+      - name: Test minimum supported Narwhals
+        run: uv run nox -s minimum_versions

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI now runs the stable suite with Python 3.10 and Narwhals 2.20.0, so the
+  declared minimum versions are checked on every PR. The pandas extra now
+  requires PyArrow 13, which is the minimum supported by Narwhals 2.20.0
+  (#78)
 - **Breaking:** `requires-python` is now `>= 3.10`, up from `>= 3.8`, and the
   minimum `narwhals` is 2.20.0. The two are linked: `requires-python` caps
   which narwhals is installable at all — 1.42.1 and below need 3.8, 1.43.0

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,11 +23,28 @@ def test(session):
         "hypothesis>=6.113.0",
         "polars>=0.20.21",
         "pandas>=1.5.3",
-        "pyarrow>=10.0.0",
+        "pyarrow>=13.0.0",
         "narwhals>=2.20.0",
     )
 
     session.run("pytest", "tests/")
+
+
+@nox.session(name="minimum_versions", python="3.10")
+def test_minimum_versions(session):
+    """Run the stable suite at the Python and narwhals floors."""
+    session.install(
+        "pytest==8.3.2",
+        "hypothesis>=6.113.0",
+        "polars>=0.20.21",
+        "pandas>=1.5.3",
+        "pyarrow>=13.0.0",
+        "narwhals==2.20.0",
+    )
+    # Property tests check statistical behavior against random data. They do
+    # not exercise a separate Narwhals API surface, so the ordinary CI job
+    # runs them once with the locked environment.
+    session.run("pytest", "tests/", "--ignore=tests/test_properties.py")
 
 
 @nox.parametrize("polars_version", ["0.20.21", "1.4.1"])
@@ -39,7 +56,7 @@ def test_polars_versions(session, polars_version, pandas_version):
         "hypothesis>=6.113.0",
         f"polars=={polars_version}",
         f"pandas>={pandas_version}",
-        "pyarrow>=10.0.0",
+        "pyarrow>=13.0.0",
         "narwhals>=2.20.0",
     )
     session.run("pytest", "tests/")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = ">= 3.10"
 # Convenience extras for people who want a dataframe library installed
 # alongside showstats. None of them is required: showstats works with
 # whatever narwhals-compatible frame it is handed.
-pandas = ["pandas>=1.5.3", "pyarrow>=10.0.0"]
+pandas = ["pandas>=1.5.3", "pyarrow>=13.0.0"]
 polars = ["polars>=0.20.21"]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2830,7 +2830,7 @@ requires-dist = [
     { name = "narwhals", specifier = ">=2.20.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.5.3" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=0.20.21" },
-    { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=10.0.0" },
+    { name = "pyarrow", marker = "extra == 'pandas'", specifier = ">=13.0.0" },
 ]
 provides-extras = ["pandas", "polars"]
 


### PR DESCRIPTION
## What

This adds a minimum dependency test session on Python 3.10 with Narwhals 2.20. It also raises the pandas extra PyArrow floor to version 13, which is the version required by that Narwhals release.

## Why

Closes #78.

The package metadata already declares supported floors. This PR makes CI test those floors on every change.

## Verify

```shell
uv run pytest
uv run nox -s minimum_versions
uv run ruff check .
uv run ruff format --check .
```

## Risk

This changes CI and dependency metadata. It does not change runtime behavior.
