### PR TITLE
Prepare release 0.3.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-08-23
+
 ### Added
 
 - `show_stats(..., fmt="gt")` returns styled Great Tables output. Great Tables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
 ]
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 requires-python = ">= 3.10"
 


### PR DESCRIPTION
## Summary

- Set the package version to 0.3.0.
- Move the current Unreleased changes into the 0.3.0 section dated 2026-08-23.

## Checks

- uv run pytest
- uv run ruff check .
- uv build
- uv run twine check dist/showstats-0.3.0.tar.gz dist/showstats-0.3.0-py3-none-any.whl